### PR TITLE
[design] Deduplicate image-credential check

### DIFF
--- a/.forge/specs/image-creds-dedup/decomposition.md
+++ b/.forge/specs/image-creds-dedup/decomposition.md
@@ -1,0 +1,22 @@
+# Deduplicate image-credential check
+
+> Feature **image-creds-dedup** — base branch `main`,
+> branch prefix `forge`.
+
+## Pieces
+
+<!-- forge:order-start -->
+1. <!-- forge:piece p1 -->**p1: Extract shared image-credential check**<!-- /forge:piece -->
+   <!-- forge:editable-summary p1 -->
+   Add ImageProvider.imageCredsAvailable + huggingFaceKey and route all six duplicated image-credential sites through them.
+   <!-- /forge:editable-summary -->
+   <!-- forge:status p1 -->`pending`<!-- /forge:status -->
+
+<!-- forge:order-end -->
+
+---
+
+*Rendered by [Forge](https://github.com/anthropics/forge) from
+`manifest.json`. Edit a piece summary or reorder the list between the
+`forge:order-start` / `forge:order-end` markers above, then run
+`forge reconcile image-creds-dedup` to import the change.*

--- a/.forge/specs/image-creds-dedup/design.md
+++ b/.forge/specs/image-creds-dedup/design.md
@@ -1,0 +1,112 @@
+# image-creds-dedup
+
+## Problem
+
+The logic that decides whether the configured image provider has the
+credentials it needs is copy-pasted across the backend, and the
+HuggingFace key-fallback chain is repeated on top of that. The same
+`config.imageProvider match { ... }` boolean block appears in five places,
+and the HuggingFace key chain appears in a sixth:
+
+- `api/SzorkConfig.scala` — `validate()` (~lines 261-279), a validation
+  variant that appends error strings.
+- `api/SzorkServer.scala` — `imageKeysPresent` field (~line 114).
+- `api/SzorkServer.scala` — `/api/feature-flags` endpoint, local
+  `imageCreds` (~line 146).
+- `websocket/TypedWebSocketServer.scala` — `handleNewGame()`, local
+  `imageCredsAvailable` (~line 278).
+- `websocket/TypedWebSocketServer.scala` — `handleLoadGame()`, local
+  `imageCredsAvailable` (~line 486).
+- `media/ImageGeneration.scala` — client construction (~lines 27-30)
+  repeats the HuggingFace key chain
+  (`HUGGINGFACE_API_KEY` → `HF_API_KEY` → `HUGGINGFACE_TOKEN`) before
+  `.getOrElse(throw ...)`.
+
+The four boolean copies are byte-for-byte identical:
+
+```scala
+config.imageProvider match {
+  case ImageProvider.HuggingFace | ImageProvider.HuggingFaceSDXL =>
+    EnvLoader.get("HUGGINGFACE_API_KEY")
+      .orElse(EnvLoader.get("HF_API_KEY"))
+      .orElse(EnvLoader.get("HUGGINGFACE_TOKEN"))
+      .exists(_.nonEmpty)
+  case ImageProvider.OpenAIDalle2 | ImageProvider.OpenAIDalle3 => openAIKeyPresent
+  case ImageProvider.LocalStableDiffusion => true
+  case ImageProvider.None => false
+}
+```
+
+Because the rule lives in six spots, the HuggingFace key-fallback chain
+and the per-provider rules can (and will) drift between them. A new image
+provider, or a new env-var fallback, has to be edited everywhere.
+
+## Approach
+
+Backend DRY refactor only. Add two shared members to the `ImageProvider`
+companion object in `api/SzorkConfig.scala` and route every site through
+them:
+
+- `def huggingFaceKey(reader: ConfigReader = EnvLoader): Option[String]` —
+  resolves the HuggingFace key fallback chain
+  (`HUGGINGFACE_API_KEY` → `HF_API_KEY` → `HUGGINGFACE_TOKEN`), returning
+  the first present, non-empty value.
+- `def imageCredsAvailable(provider: ImageProvider, reader: ConfigReader =
+  EnvLoader): Boolean` — the per-provider availability rule:
+  - HuggingFace / HuggingFaceSDXL ⇒ `huggingFaceKey(reader).exists(_.nonEmpty)`.
+  - OpenAIDalle2 / OpenAIDalle3 ⇒ `OPENAI_API_KEY` present and non-empty.
+  - LocalStableDiffusion ⇒ `true`.
+  - None ⇒ `false`.
+
+Both take an optional `ConfigReader` (the existing trait in
+`org.llm4s.config`) defaulting to `EnvLoader`. Production call sites omit
+it and get the `EnvLoader` default — no behaviour change — while the unit
+test injects a fake reader to exercise every branch deterministically.
+
+Then:
+
+- Replace the four boolean duplicates (`imageKeysPresent`, the
+  `featureFlags` local, both `imageCredsAvailable` locals) with
+  `ImageProvider.imageCredsAvailable(config.imageProvider)`.
+- Rework the image-provider branch of `SzorkConfig.validate()` to reuse
+  `imageCredsAvailable`, appending today's error messages when it returns
+  `false` for an enabled non-`None` provider.
+- In `ImageGeneration.scala`, replace the inline HuggingFace key chain
+  with `ImageProvider.huggingFaceKey`, keeping the existing
+  `.getOrElse(throw new IllegalStateException(...))` and its exact
+  message. Other branches (OpenAI, LocalStableDiffusion) are unchanged.
+
+The OpenAI-DALL-E branch of `imageCredsAvailable` reads the OpenAI key via
+the injected `reader` (`reader.get("OPENAI_API_KEY").exists(_.nonEmpty)`).
+
+## Testing
+
+Add one ScalaTest spec (`*Spec.scala`, matching the existing suite) that
+constructs a fake `ConfigReader` and asserts the full mapping:
+HuggingFace/HuggingFaceSDXL keyed on the three-way key chain (including the
+fallback order and the empty-string-is-absent rule), DALL-E 2/3 keyed on
+`OPENAI_API_KEY`, LocalStableDiffusion always `true`, None always `false`,
+plus `huggingFaceKey` returning the first non-empty key in priority order.
+
+## Non-goals
+
+- No change to the duplicated `openAIKeyPresent` / `replicateKeyPresent`
+  fields shared between `SzorkServer` and `TypedWebSocketServer` (they are
+  used elsewhere and stay as-is).
+- No consolidation of TTS / STT / music client construction or their
+  credential handling.
+- No change to the OpenAI or LocalStableDiffusion client-construction
+  branches in `ImageGeneration.scala` beyond the HF-key extraction.
+- No new behaviour, no change to which providers are considered available,
+  and no change to user-visible feature flags or error/exception messages.
+
+## Decisions
+
+- The shared members live on the `ImageProvider` companion object (same
+  file as the provider definition) rather than a new module — natural
+  home, no new abstraction for a small refactor.
+- Helper names follow the existing call-site vocabulary:
+  `imageCredsAvailable` (the boolean) and `huggingFaceKey` (the resolved
+  key).
+- Scope is image credentials only, matching the feature name. Broader
+  media-credential consolidation was considered and deliberately deferred.

--- a/.forge/specs/image-creds-dedup/manifest.json
+++ b/.forge/specs/image-creds-dedup/manifest.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "featureId": "image-creds-dedup",
+  "title": "Deduplicate image-credential check",
+  "baseBranch": "main",
+  "branchPrefix": "forge",
+  "mode": "claude-driver",
+  "designPr": null,
+  "pieces": [
+    {
+      "id": "p1",
+      "order": 1,
+      "title": "Extract shared image-credential check",
+      "summary": "Add ImageProvider.imageCredsAvailable + huggingFaceKey and route all six duplicated image-credential sites through them.",
+      "specPath": "pieces/p1.md",
+      "acceptanceHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "status": "pending",
+      "baseSha": null,
+      "prNumber": null,
+      "mergeCommit": null,
+      "mergedAt": null,
+      "attempts": 0
+    }
+  ]
+}

--- a/.forge/specs/image-creds-dedup/pieces/p1.md
+++ b/.forge/specs/image-creds-dedup/pieces/p1.md
@@ -1,0 +1,93 @@
+# p1 — Extract shared image-credential check
+
+## Summary
+
+Add `ImageProvider.imageCredsAvailable` and `ImageProvider.huggingFaceKey`,
+route all six duplicated image-credential sites through them, and add a
+unit test — with no behaviour change.
+
+## Context
+
+The per-provider "are image credentials present?" rule is duplicated in
+five locations (four identical boolean copies, one validation variant),
+and the HuggingFace key chain is repeated a sixth time in image client
+construction. See `design.md` for the full inventory and the exact
+duplicated snippet.
+
+## Changes
+
+1. In `src/main/scala/org/llm4s/szork/api/SzorkConfig.scala`, add to the
+   `ImageProvider` companion object (importing `ConfigReader` from
+   `org.llm4s.config`):
+
+   ```scala
+   def huggingFaceKey(reader: ConfigReader = EnvLoader): Option[String]
+   def imageCredsAvailable(provider: ImageProvider, reader: ConfigReader = EnvLoader): Boolean
+   ```
+
+   - `huggingFaceKey` returns the first present, non-empty value of
+     `HUGGINGFACE_API_KEY`, then `HF_API_KEY`, then `HUGGINGFACE_TOKEN`
+     (read via `reader`).
+   - `imageCredsAvailable` returns:
+     - HuggingFace / HuggingFaceSDXL ⇒ `huggingFaceKey(reader).exists(_.nonEmpty)`.
+     - OpenAIDalle2 / OpenAIDalle3 ⇒ `reader.get("OPENAI_API_KEY").exists(_.nonEmpty)`.
+     - LocalStableDiffusion ⇒ `true`.
+     - None ⇒ `false`.
+
+   Both default `reader` to `EnvLoader`, so existing call sites omit it.
+
+2. Replace the four boolean duplicates with
+   `ImageProvider.imageCredsAvailable(config.imageProvider)`:
+   - `SzorkServer.scala` — `imageKeysPresent` field (~L114).
+   - `SzorkServer.scala` — `imageCreds` local in `/api/feature-flags`
+     (~L146).
+   - `TypedWebSocketServer.scala` — `imageCredsAvailable` in
+     `handleNewGame()` (~L278).
+   - `TypedWebSocketServer.scala` — `imageCredsAvailable` in
+     `handleLoadGame()` (~L486).
+
+3. Rewrite the image-provider branch of `SzorkConfig.validate()` (~L261)
+   to call `imageCredsAvailable`; when it returns `false` for an enabled
+   non-`None` provider, append the same error message as today
+   (HuggingFace ⇒ "HuggingFace image provider selected but no API key
+   found"; OpenAI DALL-E ⇒ "OpenAI DALL-E provider selected but
+   OPENAI_API_KEY not found").
+
+4. In `media/ImageGeneration.scala` (~L27-30), replace the inline
+   HuggingFace key chain with `ImageProvider.huggingFaceKey()`, preserving
+   the existing `.getOrElse(throw new IllegalStateException(...))` and its
+   exact message. Leave the OpenAI and LocalStableDiffusion branches
+   unchanged.
+
+5. Add a ScalaTest spec under `src/test/scala/org/llm4s/szork/` (e.g.
+   `ImageProviderCredsSpec.scala`) that uses a fake `ConfigReader` to
+   verify the full mapping and key-chain resolution.
+
+## Acceptance criteria
+
+- `ImageProvider.imageCredsAvailable(provider, reader = EnvLoader): Boolean`
+  and `ImageProvider.huggingFaceKey(reader = EnvLoader): Option[String]`
+  exist in `SzorkConfig.scala` and encode the rules above; production call
+  sites use the default `EnvLoader`.
+- The inline `config.imageProvider match { ... }` boolean block no longer
+  appears in `SzorkServer.scala` (both former sites) or
+  `TypedWebSocketServer.scala` (both former sites); each instead calls
+  `ImageProvider.imageCredsAvailable(config.imageProvider)`.
+- `SzorkConfig.validate()` no longer contains its own per-provider
+  env-var lookups for image credentials; it derives the check from
+  `imageCredsAvailable` and emits the same error strings as before.
+- `ImageGeneration.scala`'s HuggingFace branch no longer inlines the
+  `HUGGINGFACE_API_KEY`/`HF_API_KEY`/`HUGGINGFACE_TOKEN` chain; it obtains
+  the key from `ImageProvider.huggingFaceKey()` and still throws the same
+  `IllegalStateException` (same message) when absent.
+- A new ScalaTest spec passes and asserts, via a fake `ConfigReader`:
+  - HuggingFace / HuggingFaceSDXL ⇒ `true` only when one of the three keys
+    is present and non-empty; `false` when all absent or empty.
+  - `huggingFaceKey` returns the first non-empty key in priority order
+    `HUGGINGFACE_API_KEY` → `HF_API_KEY` → `HUGGINGFACE_TOKEN`.
+  - OpenAIDalle2 / OpenAIDalle3 ⇒ `true` iff `OPENAI_API_KEY` is non-empty.
+  - LocalStableDiffusion ⇒ always `true`; None ⇒ always `false`.
+- `sbt compile` succeeds and `sbt test` passes with no new failures.
+- No changes outside `SzorkConfig.scala`, `SzorkServer.scala`,
+  `TypedWebSocketServer.scala`, `ImageGeneration.scala`, and the new test
+  file.


### PR DESCRIPTION
# image-creds-dedup

## Problem

The logic that decides whether the configured image provider has the
credentials it needs is copy-pasted across the backend, and the
HuggingFace key-fallback chain is repeated on top of that. The same
`config.imageProvider match { ... }` boolean block appears in five places,
and the HuggingFace key chain appears in a sixth:

- `api/SzorkConfig.scala` — `validate()` (~lines 261-279), a validation
  variant that appends error strings.
- `api/SzorkServer.scala` — `imageKeysPresent` field (~line 114).
- `api/SzorkServer.scala` — `/api/feature-flags` endpoint, local
  `imageCreds` (~line 146).
- `websocket/TypedWebSocketServer.scala` — `handleNewGame()`, local
  `imageCredsAvailable` (~line 278).
- `websocket/TypedWebSocketServer.scala` — `handleLoadGame()`, local
  `imageCredsAvailable` (~line 486).
- `media/ImageGeneration.scala` — client construction (~lines 27-30)
  repeats the HuggingFace key chain
  (`HUGGINGFACE_API_KEY` → `HF_API_KEY` → `HUGGINGFACE_TOKEN`) before
  `.getOrElse(throw ...)`.

The four boolean copies are byte-for-byte identical:

```scala
config.imageProvider match {
  case ImageProvider.HuggingFace | ImageProvider.HuggingFaceSDXL =>
    EnvLoader.get("HUGGINGFACE_API_KEY")
      .orElse(EnvLoader.get("HF_API_KEY"))
      .orElse(EnvLoader.get("HUGGINGFACE_TOKEN"))
      .exists(_.nonEmpty)
  case ImageProvider.OpenAIDalle2 | ImageProvider.OpenAIDalle3 => openAIKeyPresent
  case ImageProvider.LocalStableDiffusion => true
  case ImageProvider.None => false
}
```

Because the rule lives in six spots, the HuggingFace key-fallback chain
and the per-provider rules can (and will) drift between them. A new image
provider, or a new env-var fallback, has to be edited everywhere.

## Approach

Backend DRY refactor only. Add two shared members to the `ImageProvider`
companion object in `api/SzorkConfig.scala` and route every site through
them:

- `def huggingFaceKey(reader: ConfigReader = EnvLoader): Option[String]` —
  resolves the HuggingFace key fallback chain
  (`HUGGINGFACE_API_KEY` → `HF_API_KEY` → `HUGGINGFACE_TOKEN`), returning
  the first present, non-empty value.
- `def imageCredsAvailable(provider: ImageProvider, reader: ConfigReader =
  EnvLoader): Boolean` — the per-provider availability rule:
  - HuggingFace / HuggingFaceSDXL ⇒ `huggingFaceKey(reader).exists(_.nonEmpty)`.
  - OpenAIDalle2 / OpenAIDalle3 ⇒ `OPENAI_API_KEY` present and non-empty.
  - LocalStableDiffusion ⇒ `true`.
  - None ⇒ `false`.

Both take an optional `ConfigReader` (the existing trait in
`org.llm4s.config`) defaulting to `EnvLoader`. Production call sites omit
it and get the `EnvLoader` default — no behaviour change — while the unit
test injects a fake reader to exercise every branch deterministically.

Then:

- Replace the four boolean duplicates (`imageKeysPresent`, the
  `featureFlags` local, both `imageCredsAvailable` locals) with
  `ImageProvider.imageCredsAvailable(config.imageProvider)`.
- Rework the image-provider branch of `SzorkConfig.validate()` to reuse
  `imageCredsAvailable`, appending today's error messages when it returns
  `false` for an enabled non-`None` provider.
- In `ImageGeneration.scala`, replace the inline HuggingFace key chain
  with `ImageProvider.huggingFaceKey`, keeping the existing
  `.getOrElse(throw new IllegalStateException(...))` and its exact
  message. Other branches (OpenAI, LocalStableDiffusion) are unchanged.

The OpenAI-DALL-E branch of `imageCredsAvailable` reads the OpenAI key via
the injected `reader` (`reader.get("OPENAI_API_KEY").exists(_.nonEmpty)`).

## Testing

Add one ScalaTest spec (`*Spec.scala`, matching the existing suite) that
constructs a fake `ConfigReader` and asserts the full mapping:
HuggingFace/HuggingFaceSDXL keyed on the three-way key chain (including the
fallback order and the empty-string-is-absent rule), DALL-E 2/3 keyed on
`OPENAI_API_KEY`, LocalStableDiffusion always `true`, None always `false`,
plus `huggingFaceKey` returning the first non-empty key in priority order.

## Non-goals

- No change to the duplicated `openAIKeyPresent` / `replicateKeyPresent`
  fields shared between `SzorkServer` and `TypedWebSocketServer` (they are
  used elsewhere and stay as-is).
- No consolidation of TTS / STT / music client construction or their
  credential handling.
- No change to the OpenAI or LocalStableDiffusion client-construction
  branches in `ImageGeneration.scala` beyond the HF-key extraction.
- No new behaviour, no change to which providers are considered available,
  and no change to user-visible feature flags or error/exception messages.

## Decisions

- The shared members live on the `ImageProvider` companion object (same
  file as the provider definition) rather than a new module — natural
  home, no new abstraction for a small refactor.
- Helper names follow the existing call-site vocabulary:
  `imageCredsAvailable` (the boolean) and `huggingFaceKey` (the resolved
  key).
- Scope is image credentials only, matching the feature name. Broader
  media-credential consolidation was considered and deliberately deferred.
