### PR TITLE
Extract shared image-credential check

### DIFF
--- a/.forge/specs/image-creds-dedup/decomposition.md
+++ b/.forge/specs/image-creds-dedup/decomposition.md
@@ -2,6 +2,7 @@
 
 > Feature **image-creds-dedup** — base branch `main`,
 > branch prefix `forge`.
+> Design PR: #9
 
 ## Pieces
 
@@ -10,7 +11,7 @@
    <!-- forge:editable-summary p1 -->
    Add ImageProvider.imageCredsAvailable + huggingFaceKey and route all six duplicated image-credential sites through them.
    <!-- /forge:editable-summary -->
-   <!-- forge:status p1 -->`pending`<!-- /forge:status -->
+   <!-- forge:status p1 -->`in progress`<!-- /forge:status -->
 
 <!-- forge:order-end -->
 

--- a/.forge/specs/image-creds-dedup/manifest.json
+++ b/.forge/specs/image-creds-dedup/manifest.json
@@ -16,10 +16,10 @@
       "acceptanceHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
       "status": "in_progress",
       "baseSha": "4c2bab11204c24de4bb456345baf02c14394003e",
-      "prNumber": null,
+      "prNumber": 10,
       "mergeCommit": null,
       "mergedAt": null,
-      "attempts": 0
+      "attempts": 1
     }
   ]
 }

--- a/.forge/specs/image-creds-dedup/manifest.json
+++ b/.forge/specs/image-creds-dedup/manifest.json
@@ -5,7 +5,7 @@
   "baseBranch": "main",
   "branchPrefix": "forge",
   "mode": "claude-driver",
-  "designPr": null,
+  "designPr": 9,
   "pieces": [
     {
       "id": "p1",
@@ -14,8 +14,8 @@
       "summary": "Add ImageProvider.imageCredsAvailable + huggingFaceKey and route all six duplicated image-credential sites through them.",
       "specPath": "pieces/p1.md",
       "acceptanceHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-      "status": "pending",
-      "baseSha": null,
+      "status": "in_progress",
+      "baseSha": "4c2bab11204c24de4bb456345baf02c14394003e",
       "prNumber": null,
       "mergeCommit": null,
       "mergedAt": null,

--- a/.forge/specs/image-creds-dedup/manifest.json
+++ b/.forge/specs/image-creds-dedup/manifest.json
@@ -19,7 +19,7 @@
       "prNumber": 10,
       "mergeCommit": null,
       "mergedAt": null,
-      "attempts": 1
+      "attempts": 2
     }
   ]
 }

--- a/.forge/specs/image-creds-dedup/pieces/p1.failures.md
+++ b/.forge/specs/image-creds-dedup/pieces/p1.failures.md
@@ -1,0 +1,12 @@
+# Piece p1 — failures to address (PR #10)
+
+These CI checks on the piece's PR did not pass (`gh pr checks`):
+
+```
+backend	pass	1m52s	https://github.com/llm4s/szork/actions/runs/26699683276/job/78690199705	
+frontend	pass	23s	https://github.com/llm4s/szork/actions/runs/26699683276/job/78690199699
+```
+
+Make the smallest change that makes the failing check(s) pass. For a formatting
+check, run the project's formatter on the changed files (a targeted format is
+fine — do NOT run the full test suite). Then stop; Forge commits and re-runs CI.

--- a/src/main/scala/org/llm4s/szork/api/SzorkConfig.scala
+++ b/src/main/scala/org/llm4s/szork/api/SzorkConfig.scala
@@ -47,9 +47,9 @@ object ImageProvider {
   def imageCredsAvailable(provider: ImageProvider, reader: ConfigReader = EnvLoader): Boolean =
     provider match {
       case HuggingFace | HuggingFaceSDXL => huggingFaceKey(reader).exists(_.nonEmpty)
-      case OpenAIDalle2 | OpenAIDalle3   => reader.get("OPENAI_API_KEY").exists(_.nonEmpty)
-      case LocalStableDiffusion          => true
-      case None                          => false
+      case OpenAIDalle2 | OpenAIDalle3 => reader.get("OPENAI_API_KEY").exists(_.nonEmpty)
+      case LocalStableDiffusion => true
+      case None => false
     }
 }
 
@@ -275,10 +275,8 @@ object SzorkConfig {
       }
 
       // Validate image provider configuration
-      if (
-        config.imageGenerationEnabled && config.imageProvider != ImageProvider.None
-        && !ImageProvider.imageCredsAvailable(config.imageProvider)
-      ) {
+      if (config.imageGenerationEnabled && config.imageProvider != ImageProvider.None
+        && !ImageProvider.imageCredsAvailable(config.imageProvider)) {
         config.imageProvider match {
           case ImageProvider.HuggingFace | ImageProvider.HuggingFaceSDXL =>
             errors += "HuggingFace image provider selected but no API key found"

--- a/src/main/scala/org/llm4s/szork/api/SzorkConfig.scala
+++ b/src/main/scala/org/llm4s/szork/api/SzorkConfig.scala
@@ -2,7 +2,7 @@ package org.llm4s.szork.api
 
 import org.llm4s.szork.error._
 import org.llm4s.szork.error.ErrorHandling._
-import org.llm4s.config.EnvLoader
+import org.llm4s.config.{ConfigReader, EnvLoader}
 import org.slf4j.Logger
 
 /** Image generation provider options
@@ -34,6 +34,23 @@ object ImageProvider {
     case OpenAIDalle3 => "OpenAI DALL-E 3"
     case LocalStableDiffusion => "Local Stable Diffusion"
   }
+
+  /** Resolve the HuggingFace API key from the supported env keys, in priority order. */
+  def huggingFaceKey(reader: ConfigReader = EnvLoader): Option[String] =
+    reader
+      .get("HUGGINGFACE_API_KEY")
+      .filter(_.nonEmpty)
+      .orElse(reader.get("HF_API_KEY").filter(_.nonEmpty))
+      .orElse(reader.get("HUGGINGFACE_TOKEN").filter(_.nonEmpty))
+
+  /** Whether the credentials required by the given image provider are available. */
+  def imageCredsAvailable(provider: ImageProvider, reader: ConfigReader = EnvLoader): Boolean =
+    provider match {
+      case HuggingFace | HuggingFaceSDXL => huggingFaceKey(reader).exists(_.nonEmpty)
+      case OpenAIDalle2 | OpenAIDalle3   => reader.get("OPENAI_API_KEY").exists(_.nonEmpty)
+      case LocalStableDiffusion          => true
+      case None                          => false
+    }
 }
 
 /** Configuration for the Szork game server
@@ -258,23 +275,15 @@ object SzorkConfig {
       }
 
       // Validate image provider configuration
-      if (config.imageGenerationEnabled && config.imageProvider != ImageProvider.None) {
+      if (
+        config.imageGenerationEnabled && config.imageProvider != ImageProvider.None
+        && !ImageProvider.imageCredsAvailable(config.imageProvider)
+      ) {
         config.imageProvider match {
           case ImageProvider.HuggingFace | ImageProvider.HuggingFaceSDXL =>
-            if (EnvLoader.get("HUGGINGFACE_API_KEY").isEmpty &&
-              EnvLoader.get("HF_API_KEY").isEmpty &&
-              EnvLoader.get("HUGGINGFACE_TOKEN").isEmpty) {
-              errors += "HuggingFace image provider selected but no API key found"
-            }
-
+            errors += "HuggingFace image provider selected but no API key found"
           case ImageProvider.OpenAIDalle2 | ImageProvider.OpenAIDalle3 =>
-            if (EnvLoader.get("OPENAI_API_KEY").isEmpty) {
-              errors += "OpenAI DALL-E provider selected but OPENAI_API_KEY not found"
-            }
-
-          case ImageProvider.LocalStableDiffusion =>
-            // No API key required; ensure a base URL is configured or default applies
-            ()
+            errors += "OpenAI DALL-E provider selected but OPENAI_API_KEY not found"
           case _ => ()
         }
       }

--- a/src/main/scala/org/llm4s/szork/api/SzorkServer.scala
+++ b/src/main/scala/org/llm4s/szork/api/SzorkServer.scala
@@ -111,17 +111,7 @@ object SzorkServer extends cask.Main with cask.Routes {
   private val musicRequested = config.musicEnabled
 
   private val imageRequested = config.imageGenerationEnabled && config.imageProvider != ImageProvider.None
-  private val imageKeysPresent: Boolean = config.imageProvider match {
-    case ImageProvider.HuggingFace | ImageProvider.HuggingFaceSDXL =>
-      EnvLoader
-        .get("HUGGINGFACE_API_KEY")
-        .orElse(EnvLoader.get("HF_API_KEY"))
-        .orElse(EnvLoader.get("HUGGINGFACE_TOKEN"))
-        .exists(_.nonEmpty)
-    case ImageProvider.OpenAIDalle2 | ImageProvider.OpenAIDalle3 => openAIKeyPresent
-    case ImageProvider.LocalStableDiffusion => true
-    case ImageProvider.None => false
-  }
+  private val imageKeysPresent: Boolean = ImageProvider.imageCredsAvailable(config.imageProvider)
 
   logger.info("=== Feature Availability ===")
   logger.info(s"LLM Text Generation: ${config.llmConfig.map(_.provider).getOrElse("Unavailable")}")
@@ -143,17 +133,7 @@ object SzorkServer extends cask.Main with cask.Routes {
   @get("/api/feature-flags")
   def featureFlags(): ujson.Value = {
     val imageRequested = config.imageGenerationEnabled && config.imageProvider != ImageProvider.None
-    val imageCreds = config.imageProvider match {
-      case ImageProvider.HuggingFace | ImageProvider.HuggingFaceSDXL =>
-        EnvLoader
-          .get("HUGGINGFACE_API_KEY")
-          .orElse(EnvLoader.get("HF_API_KEY"))
-          .orElse(EnvLoader.get("HUGGINGFACE_TOKEN"))
-          .exists(_.nonEmpty)
-      case ImageProvider.OpenAIDalle2 | ImageProvider.OpenAIDalle3 => openAIKeyPresent
-      case ImageProvider.LocalStableDiffusion => true
-      case ImageProvider.None => false
-    }
+    val imageCreds = ImageProvider.imageCredsAvailable(config.imageProvider)
     ujson.Obj(
       "llm" -> ujson.Obj(
         "provider" -> config.llmConfig.map(_.provider).getOrElse(""),

--- a/src/main/scala/org/llm4s/szork/media/ImageGeneration.scala
+++ b/src/main/scala/org/llm4s/szork/media/ImageGeneration.scala
@@ -24,10 +24,8 @@ class ImageGeneration {
           (None, "None")
 
         case ImageProvider.HuggingFace | ImageProvider.HuggingFaceSDXL =>
-          val hfKey = EnvLoader
-            .get("HUGGINGFACE_API_KEY")
-            .orElse(EnvLoader.get("HF_API_KEY"))
-            .orElse(EnvLoader.get("HUGGINGFACE_TOKEN"))
+          val hfKey = ImageProvider
+            .huggingFaceKey()
             .getOrElse(
               throw new IllegalStateException(
                 s"Image provider set to ${ImageProvider.toString(config.imageProvider)} but no HuggingFace API key found. " +

--- a/src/main/scala/org/llm4s/szork/websocket/TypedWebSocketServer.scala
+++ b/src/main/scala/org/llm4s/szork/websocket/TypedWebSocketServer.scala
@@ -13,7 +13,6 @@ import org.llm4s.szork.websocket.{protocol => proto}
 import proto._
 import org.llm4s.szork.adapters._
 import org.llm4s.szork.spi.SystemClock
-import org.llm4s.config.EnvLoader
 import org.llm4s.szork.game._
 import org.llm4s.szork.persistence.{ConversationEntry => _, _}
 import org.llm4s.szork.api.{CommandRequest => _, _}
@@ -275,17 +274,7 @@ class TypedWebSocketServer(
     }
 
     // Create GameEngine with proper parameters
-    def imageCredsAvailable: Boolean = config.imageProvider match {
-      case ImageProvider.HuggingFace | ImageProvider.HuggingFaceSDXL =>
-        EnvLoader
-          .get("HUGGINGFACE_API_KEY")
-          .orElse(EnvLoader.get("HF_API_KEY"))
-          .orElse(EnvLoader.get("HUGGINGFACE_TOKEN"))
-          .exists(_.nonEmpty)
-      case ImageProvider.OpenAIDalle2 | ImageProvider.OpenAIDalle3 => openAIKeyPresent
-      case ImageProvider.LocalStableDiffusion => true
-      case ImageProvider.None => false
-    }
+    val imageCredsAvailable: Boolean = ImageProvider.imageCredsAvailable(config.imageProvider)
 
     implicit val llmClient: org.llm4s.llmconnect.LLMClient = SzorkConfig.getLLMClient() match {
       case Right(c) => c
@@ -483,17 +472,7 @@ class TypedWebSocketServer(
             conn.send(ujson.write(errorResponse))
             return
         }
-        def imageCredsAvailable: Boolean = config.imageProvider match {
-          case ImageProvider.HuggingFace | ImageProvider.HuggingFaceSDXL =>
-            EnvLoader
-              .get("HUGGINGFACE_API_KEY")
-              .orElse(EnvLoader.get("HF_API_KEY"))
-              .orElse(EnvLoader.get("HUGGINGFACE_TOKEN"))
-              .exists(_.nonEmpty)
-          case ImageProvider.OpenAIDalle2 | ImageProvider.OpenAIDalle3 => openAIKeyPresent
-          case ImageProvider.LocalStableDiffusion => true
-          case ImageProvider.None => false
-        }
+        val imageCredsAvailable: Boolean = ImageProvider.imageCredsAvailable(config.imageProvider)
         val engine = new GameEngine(
           sessionId = sessionId,
           theme = gameState.theme.map(_.prompt),

--- a/src/test/scala/org/llm4s/szork/ImageProviderCredsSpec.scala
+++ b/src/test/scala/org/llm4s/szork/ImageProviderCredsSpec.scala
@@ -58,15 +58,13 @@ class ImageProviderCredsSpec extends AnyFunSuite with Matchers {
   }
 
   test("imageCredsAvailable is true for HuggingFace providers when any HF key is present") {
-    for (provider <- Seq(ImageProvider.HuggingFace, ImageProvider.HuggingFaceSDXL)) {
+    for (provider <- Seq(ImageProvider.HuggingFace, ImageProvider.HuggingFaceSDXL))
       ImageProvider.imageCredsAvailable(provider, FakeReader(Map("HF_API_KEY" -> "k"))) shouldBe true
-    }
   }
 
   test("imageCredsAvailable is false for HuggingFace providers when all HF keys are absent") {
-    for (provider <- Seq(ImageProvider.HuggingFace, ImageProvider.HuggingFaceSDXL)) {
+    for (provider <- Seq(ImageProvider.HuggingFace, ImageProvider.HuggingFaceSDXL))
       ImageProvider.imageCredsAvailable(provider, emptyReader) shouldBe false
-    }
   }
 
   test("imageCredsAvailable is false for HuggingFace providers when all HF keys are empty strings") {
@@ -76,9 +74,8 @@ class ImageProviderCredsSpec extends AnyFunSuite with Matchers {
         "HF_API_KEY" -> "",
         "HUGGINGFACE_TOKEN" -> ""
       ))
-    for (provider <- Seq(ImageProvider.HuggingFace, ImageProvider.HuggingFaceSDXL)) {
+    for (provider <- Seq(ImageProvider.HuggingFace, ImageProvider.HuggingFaceSDXL))
       ImageProvider.imageCredsAvailable(provider, reader) shouldBe false
-    }
   }
 
   test("imageCredsAvailable for OpenAI DALL-E providers is true iff OPENAI_API_KEY is non-empty") {

--- a/src/test/scala/org/llm4s/szork/ImageProviderCredsSpec.scala
+++ b/src/test/scala/org/llm4s/szork/ImageProviderCredsSpec.scala
@@ -1,0 +1,99 @@
+package org.llm4s.szork
+
+import org.llm4s.config.ConfigReader
+import org.llm4s.szork.api.ImageProvider
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class ImageProviderCredsSpec extends AnyFunSuite with Matchers {
+
+  /** A deterministic in-memory ConfigReader backed by a Map. */
+  private final case class FakeReader(values: Map[String, String]) extends ConfigReader {
+    override def get(key: String): Option[String] = values.get(key)
+  }
+
+  private val emptyReader = FakeReader(Map.empty)
+
+  test("huggingFaceKey returns the first non-empty key in priority order") {
+    val reader = FakeReader(
+      Map(
+        "HUGGINGFACE_API_KEY" -> "primary",
+        "HF_API_KEY" -> "secondary",
+        "HUGGINGFACE_TOKEN" -> "tertiary"
+      ))
+    ImageProvider.huggingFaceKey(reader) shouldBe Some("primary")
+  }
+
+  test("huggingFaceKey skips an empty HUGGINGFACE_API_KEY and falls back to HF_API_KEY") {
+    val reader = FakeReader(
+      Map(
+        "HUGGINGFACE_API_KEY" -> "",
+        "HF_API_KEY" -> "secondary",
+        "HUGGINGFACE_TOKEN" -> "tertiary"
+      ))
+    ImageProvider.huggingFaceKey(reader) shouldBe Some("secondary")
+  }
+
+  test("huggingFaceKey falls back to HUGGINGFACE_TOKEN when the first two are empty/absent") {
+    val reader = FakeReader(
+      Map(
+        "HUGGINGFACE_API_KEY" -> "",
+        "HUGGINGFACE_TOKEN" -> "tertiary"
+      ))
+    ImageProvider.huggingFaceKey(reader) shouldBe Some("tertiary")
+  }
+
+  test("huggingFaceKey returns None when all keys are absent") {
+    ImageProvider.huggingFaceKey(emptyReader) shouldBe None
+  }
+
+  test("huggingFaceKey returns None when all keys are empty strings") {
+    val reader = FakeReader(
+      Map(
+        "HUGGINGFACE_API_KEY" -> "",
+        "HF_API_KEY" -> "",
+        "HUGGINGFACE_TOKEN" -> ""
+      ))
+    ImageProvider.huggingFaceKey(reader) shouldBe None
+  }
+
+  test("imageCredsAvailable is true for HuggingFace providers when any HF key is present") {
+    for (provider <- Seq(ImageProvider.HuggingFace, ImageProvider.HuggingFaceSDXL)) {
+      ImageProvider.imageCredsAvailable(provider, FakeReader(Map("HF_API_KEY" -> "k"))) shouldBe true
+    }
+  }
+
+  test("imageCredsAvailable is false for HuggingFace providers when all HF keys are absent") {
+    for (provider <- Seq(ImageProvider.HuggingFace, ImageProvider.HuggingFaceSDXL)) {
+      ImageProvider.imageCredsAvailable(provider, emptyReader) shouldBe false
+    }
+  }
+
+  test("imageCredsAvailable is false for HuggingFace providers when all HF keys are empty strings") {
+    val reader = FakeReader(
+      Map(
+        "HUGGINGFACE_API_KEY" -> "",
+        "HF_API_KEY" -> "",
+        "HUGGINGFACE_TOKEN" -> ""
+      ))
+    for (provider <- Seq(ImageProvider.HuggingFace, ImageProvider.HuggingFaceSDXL)) {
+      ImageProvider.imageCredsAvailable(provider, reader) shouldBe false
+    }
+  }
+
+  test("imageCredsAvailable for OpenAI DALL-E providers is true iff OPENAI_API_KEY is non-empty") {
+    for (provider <- Seq(ImageProvider.OpenAIDalle2, ImageProvider.OpenAIDalle3)) {
+      ImageProvider.imageCredsAvailable(provider, FakeReader(Map("OPENAI_API_KEY" -> "k"))) shouldBe true
+      ImageProvider.imageCredsAvailable(provider, FakeReader(Map("OPENAI_API_KEY" -> ""))) shouldBe false
+      ImageProvider.imageCredsAvailable(provider, emptyReader) shouldBe false
+    }
+  }
+
+  test("imageCredsAvailable for LocalStableDiffusion is always true") {
+    ImageProvider.imageCredsAvailable(ImageProvider.LocalStableDiffusion, emptyReader) shouldBe true
+  }
+
+  test("imageCredsAvailable for None is always false") {
+    ImageProvider.imageCredsAvailable(ImageProvider.None, FakeReader(Map("OPENAI_API_KEY" -> "k"))) shouldBe false
+  }
+}


### PR DESCRIPTION
# Extract shared image-credential check

> Piece **p1** of feature [Deduplicate image-credential check](../specs/image-creds-dedup/design.md).
> Design PR: #9

## Summary

Add ImageProvider.imageCredsAvailable + huggingFaceKey and route all six duplicated image-credential sites through them.

## Spec

# p1 — Extract shared image-credential check

## Summary

Add `ImageProvider.imageCredsAvailable` and `ImageProvider.huggingFaceKey`,
route all six duplicated image-credential sites through them, and add a
unit test — with no behaviour change.

## Context

The per-provider "are image credentials present?" rule is duplicated in
five locations (four identical boolean copies, one validation variant),
and the HuggingFace key chain is repeated a sixth time in image client
construction. See `design.md` for the full inventory and the exact
duplicated snippet.

## Changes

1. In `src/main/scala/org/llm4s/szork/api/SzorkConfig.scala`, add to the
   `ImageProvider` companion object (importing `ConfigReader` from
   `org.llm4s.config`):

   ```scala
   def huggingFaceKey(reader: ConfigReader = EnvLoader): Option[String]
   def imageCredsAvailable(provider: ImageProvider, reader: ConfigReader = EnvLoader): Boolean
   ```

   - `huggingFaceKey` returns the first present, non-empty value of
     `HUGGINGFACE_API_KEY`, then `HF_API_KEY`, then `HUGGINGFACE_TOKEN`
     (read via `reader`).
   - `imageCredsAvailable` returns:
     - HuggingFace / HuggingFaceSDXL ⇒ `huggingFaceKey(reader).exists(_.nonEmpty)`.
     - OpenAIDalle2 / OpenAIDalle3 ⇒ `reader.get("OPENAI_API_KEY").exists(_.nonEmpty)`.
     - LocalStableDiffusion ⇒ `true`.
     - None ⇒ `false`.

   Both default `reader` to `EnvLoader`, so existing call sites omit it.

2. Replace the four boolean duplicates with
   `ImageProvider.imageCredsAvailable(config.imageProvider)`:
   - `SzorkServer.scala` — `imageKeysPresent` field (~L114).
   - `SzorkServer.scala` — `imageCreds` local in `/api/feature-flags`
     (~L146).
   - `TypedWebSocketServer.scala` — `imageCredsAvailable` in
     `handleNewGame()` (~L278).
   - `TypedWebSocketServer.scala` — `imageCredsAvailable` in
     `handleLoadGame()` (~L486).

3. Rewrite the image-provider branch of `SzorkConfig.validate()` (~L261)
   to call `imageCredsAvailable`; when it returns `false` for an enabled
   non-`None` provider, append the same error message as today
   (HuggingFace ⇒ "HuggingFace image provider selected but no API key
   found"; OpenAI DALL-E ⇒ "OpenAI DALL-E provider selected but
   OPENAI_API_KEY not found").

4. In `media/ImageGeneration.scala` (~L27-30), replace the inline
   HuggingFace key chain with `ImageProvider.huggingFaceKey()`, preserving
   the existing `.getOrElse(throw new IllegalStateException(...))` and its
   exact message. Leave the OpenAI and LocalStableDiffusion branches
   unchanged.

5. Add a ScalaTest spec under `src/test/scala/org/llm4s/szork/` (e.g.
   `ImageProviderCredsSpec.scala`) that uses a fake `ConfigReader` to
   verify the full mapping and key-chain resolution.

## Acceptance criteria

- `ImageProvider.imageCredsAvailable(provider, reader = EnvLoader): Boolean`
  and `ImageProvider.huggingFaceKey(reader = EnvLoader): Option[String]`
  exist in `SzorkConfig.scala` and encode the rules above; production call
  sites use the default `EnvLoader`.
- The inline `config.imageProvider match { ... }` boolean block no longer
  appears in `SzorkServer.scala` (both former sites) or
  `TypedWebSocketServer.scala` (both former sites); each instead calls
  `ImageProvider.imageCredsAvailable(config.imageProvider)`.
- `SzorkConfig.validate()` no longer contains its own per-provider
  env-var lookups for image credentials; it derives the check from
  `imageCredsAvailable` and emits the same error strings as before.
- `ImageGeneration.scala`'s HuggingFace branch no longer inlines the
  `HUGGINGFACE_API_KEY`/`HF_API_KEY`/`HUGGINGFACE_TOKEN` chain; it obtains
  the key from `ImageProvider.huggingFaceKey()` and still throws the same
  `IllegalStateException` (same message) when absent.
- A new ScalaTest spec passes and asserts, via a fake `ConfigReader`:
  - HuggingFace / HuggingFaceSDXL ⇒ `true` only when one of the three keys
    is present and non-empty; `false` when all absent or empty.
  - `huggingFaceKey` returns the first non-empty key in priority order
    `HUGGINGFACE_API_KEY` → `HF_API_KEY` → `HUGGINGFACE_TOKEN`.
  - OpenAIDalle2 / OpenAIDalle3 ⇒ `true` iff `OPENAI_API_KEY` is non-empty.
  - LocalStableDiffusion ⇒ always `true`; None ⇒ always `false`.
- `sbt compile` succeeds and `sbt test` passes with no new failures.
- No changes outside `SzorkConfig.scala`, `SzorkServer.scala`,
  `TypedWebSocketServer.scala`, `ImageGeneration.scala`, and the new test
  file.


## Audit

Implemented by the Forge claude driver.

---

*Opened by [Forge](https://github.com/anthropics/forge). Reviewed by the cross-model reviewer; merged by a human after CI passes.*
