### PR TITLE
Migrate szork to Scala 3 (llm4s 0.3.2)

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -5,7 +5,7 @@ align.preset = none
 rewrite.rules = [RedundantBraces, RedundantParens]
 danglingParentheses.preset = false
 assumeStandardLibraryStripMargin = true
-runner.dialect = scala213
+runner.dialect = scala3
 
 continuationIndent.defnSite = 2
 continuationIndent.callSite = 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Szork is an AI-powered text adventure game built with Scala 2.13 and the LLM4S library. It combines classic text adventure gameplay with modern AI features including:
+Szork is an AI-powered text adventure game built with Scala 3 and the LLM4S library. It combines classic text adventure gameplay with modern AI features including:
 
 - AI Dungeon Master using GPT-4/Claude for dynamic narratives
 - Voice control (Speech-to-Text) and narrated responses (Text-to-Speech) 
@@ -158,7 +158,7 @@ sbt "testOnly * -- -z inventory"  # Run tests matching pattern
 
 ## Code Style
 
-- Follow Scala 2.13 conventions
+- Follow Scala 3 conventions
 - Use consistent error handling with `Either[String, T]` 
 - Comprehensive logging with structured messages
 - Immutable data structures where possible

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.16"
+ThisBuild / scalaVersion := "3.7.1"
 ThisBuild / organization := "org.llm4s"
 ThisBuild / organizationName := "llm4s"
 
@@ -24,26 +24,20 @@ lazy val root = (project in file("."))
     reStartArgs := Seq(),
     Global / cancelable := true,
     
-    // Compiler options for Scala 2.13
+    // Compiler options for Scala 3
     scalacOptions ++= Seq(
       "-feature",
       "-unchecked",
       "-deprecation",
-      "-Wunused:nowarn",
-      "-Wunused:imports",
-      "-Wunused:privates",
-      "-Wunused:locals",
-      "-Wunused:patvars",
-      "-Wunused:params",
-      "-Wunused:linted",
+      "-source:3.3",
       // Suppress exhaustiveness warnings that are false positives with cask annotations
       "-Wconf:msg=match may not be exhaustive:s"
     ),
     
     // Dependencies
     libraryDependencies ++= Seq(
-      // Core LLM4S library
-      "org.llm4s" %% "core" % "0.2.5",
+      // Core LLM4S library (Scala 3 default build)
+      "org.llm4s" %% "core" % "0.3.2",
       
       // Cask for web server
       "com.lihaoyi" %% "cask" % "0.10.2",
@@ -57,7 +51,7 @@ lazy val root = (project in file("."))
       
       // LLM provider dependencies
       "com.azure"          % "azure-ai-openai" % "1.0.0-beta.16",
-      "com.anthropic"      % "anthropic-java"  % "2.2.0",
+      "com.anthropic"      % "anthropic-java"  % "2.11.1",
       "com.knuddels"       % "jtokkit"         % "1.1.0",
       
       // HTTP and WebSocket

--- a/src/main/scala/org/llm4s/szork/api/SzorkConfig.scala
+++ b/src/main/scala/org/llm4s/szork/api/SzorkConfig.scala
@@ -129,7 +129,10 @@ object SzorkConfig {
     instance.llmConfig match {
       case Some(config) =>
         try
-          org.llm4s.llmconnect.LLMConnect.getClient(config.toProviderConfig).left.map(_.message)
+          org.llm4s.model.ModelRegistryService.default().left.map(_.message).flatMap { registry =>
+            given org.llm4s.model.ModelRegistryService = registry
+            org.llm4s.llmconnect.LLMConnect.getClient(config.toProviderConfig).left.map(_.message)
+          }
         catch {
           case e: Exception => Left(s"Failed to create LLM client: ${e.getMessage}")
         }
@@ -301,9 +304,10 @@ object SzorkConfig {
     def logConfiguration(logger: Logger): Unit = {
       logger.info("=== Szork Configuration ===")
       logger.info(s"Server: ${config.host}:${config.port}")
-      logger.info(
-        s"Image Generation: ${if (config.imageGenerationEnabled) s"Enabled (${ImageProvider.toString(config.imageProvider)})"
-          else "Disabled"}")
+      logger.info(s"Image Generation: ${
+          if (config.imageGenerationEnabled) s"Enabled (${ImageProvider.toString(config.imageProvider)})"
+          else "Disabled"
+        }")
       logger.info(s"LLM Provider: ${config.llmConfig.map(_.provider).getOrElse("Not configured")}")
       logger.info(s"TTS: ${if (config.ttsEnabled) "Enabled" else "Disabled"}")
       logger.info(s"STT: ${if (config.sttEnabled) "Enabled" else "Disabled"}")

--- a/src/main/scala/org/llm4s/szork/api/SzorkServer.scala
+++ b/src/main/scala/org/llm4s/szork/api/SzorkServer.scala
@@ -115,19 +115,26 @@ object SzorkServer extends cask.Main with cask.Routes {
 
   logger.info("=== Feature Availability ===")
   logger.info(s"LLM Text Generation: ${config.llmConfig.map(_.provider).getOrElse("Unavailable")}")
-  logger.info(
-    s"Images: ${if (imageRequested && imageKeysPresent) s"Enabled (${ImageProvider.toString(config.imageProvider)})"
+  logger.info(s"Images: ${
+      if (imageRequested && imageKeysPresent) s"Enabled (${ImageProvider.toString(config.imageProvider)})"
       else if (imageRequested) s"Disabled (missing credentials for ${ImageProvider.toString(config.imageProvider)})"
-      else "Disabled"}")
-  logger.info(s"Music: ${if (musicRequested && replicateKeyPresent) "Enabled (Replicate)"
-    else if (musicRequested) "Disabled (REPLICATE_API_KEY not set)"
-    else "Disabled (by config)"}")
-  logger.info(s"Speech-to-Text: ${if (sttRequested && openAIKeyPresent) "Enabled (OpenAI Whisper)"
-    else if (sttRequested) "Disabled (OPENAI_API_KEY not set)"
-    else "Disabled (by config)"}")
-  logger.info(s"Text-to-Speech: ${if (ttsRequested && openAIKeyPresent) "Enabled (OpenAI TTS)"
-    else if (ttsRequested) "Disabled (OPENAI_API_KEY not set)"
-    else "Disabled (by config)"}")
+      else "Disabled"
+    }")
+  logger.info(s"Music: ${
+      if (musicRequested && replicateKeyPresent) "Enabled (Replicate)"
+      else if (musicRequested) "Disabled (REPLICATE_API_KEY not set)"
+      else "Disabled (by config)"
+    }")
+  logger.info(s"Speech-to-Text: ${
+      if (sttRequested && openAIKeyPresent) "Enabled (OpenAI Whisper)"
+      else if (sttRequested) "Disabled (OPENAI_API_KEY not set)"
+      else "Disabled (by config)"
+    }")
+  logger.info(s"Text-to-Speech: ${
+      if (ttsRequested && openAIKeyPresent) "Enabled (OpenAI TTS)"
+      else if (ttsRequested) "Disabled (OPENAI_API_KEY not set)"
+      else "Disabled (by config)"
+    }")
   logger.info("===========================")
 
   @get("/api/feature-flags")

--- a/src/main/scala/org/llm4s/szork/debug/RunUserStep.scala
+++ b/src/main/scala/org/llm4s/szork/debug/RunUserStep.scala
@@ -143,7 +143,7 @@ object RunUserStep {
       }
 
       // Convert engine GameResponse to StepData GameResponse
-      val gameResponse: Option[GameResponse] = response.scene.map(SceneResponse)
+      val gameResponse: Option[GameResponse] = response.scene.map(SceneResponse.apply)
 
       // Create step data
       val stepData = StepData.commandStep(

--- a/src/main/scala/org/llm4s/szork/game/GameEngine.scala
+++ b/src/main/scala/org/llm4s/szork/game/GameEngine.scala
@@ -1,6 +1,6 @@
 package org.llm4s.szork.game
 
-import org.llm4s.agent.{Agent, AgentState, AgentStatus}
+import org.llm4s.agent.{Agent, AgentContext, AgentState, AgentStatus}
 import org.llm4s.llmconnect.LLMClient
 import org.llm4s.llmconnect.model.{Message, UserMessage, AssistantMessage, SystemMessage, ToolMessage, ToolCall}
 import org.llm4s.toolapi.ToolRegistry
@@ -87,17 +87,23 @@ class GameEngine(
     val initPrompt = GameConstants.Prompts.INIT_ADVENTURE
 
     // Initialize the agent with the complete system prompt including adventure outline
-    currentState = agent.initialize(
+    currentState = agent.initializeSafe(
       initPrompt,
       toolRegistry,
       systemPromptAddition = Some(completeSystemPrompt)
-    )
+    ) match {
+      case Right(state) => state
+      case Left(error) =>
+        val szorkError = AIError(s"Failed to initialize game: ${error.message}", llmError = Some(error))
+        Logging.logError(s"[$sessionId] Initialize game")(Left(szorkError))
+        return Left(szorkError)
+    }
 
     // Track the initialization message (but don't show to user)
     // This ensures the agent knows to generate the opening scene
 
     // Automatically run the initial scene generation
-    agent.run(currentState, maxSteps = None, traceLogPath = None, debug = true) match {
+    agent.run(currentState, maxSteps = None, AgentContext(debug = true)) match {
       case Right(newState) =>
         currentState = newState
         // Extract the last textual response from the agent
@@ -177,7 +183,7 @@ class GameEngine(
     val textStartTime = System.currentTimeMillis()
     logger.debug(s"[$sessionId] Starting text generation for command: $command")
 
-    agent.run(currentState, maxSteps = None, traceLogPath = None, debug = true) match {
+    agent.run(currentState, maxSteps = None, AgentContext(debug = true)) match {
       case Right(newState) =>
         // Get only the new messages added by the agent
         val newMessages =
@@ -699,11 +705,15 @@ class GameEngine(
         case _ => "Start adventure" // Fallback
       }
 
-      currentState = agent.initialize(
+      currentState = agent.initializeSafe(
         firstMessage,
         toolRegistry,
         systemPromptAddition = Some(systemPrompt)
-      )
+      ) match {
+        case Right(state) => state
+        case Left(error) =>
+          throw new IllegalStateException(s"Failed to restore agent state: ${error.message}")
+      }
 
       // Add all the remaining messages to fully restore the conversation
       messages.tail.foreach { msg =>
@@ -722,11 +732,15 @@ class GameEngine(
       }
 
       if (messages.nonEmpty) {
-        currentState = agent.initialize(
+        currentState = agent.initializeSafe(
           messages.head.content,
           toolRegistry,
           systemPromptAddition = Some(completeSystemPrompt)
-        )
+        ) match {
+          case Right(state) => state
+          case Left(error) =>
+            throw new IllegalStateException(s"Failed to restore agent state: ${error.message}")
+        }
 
         messages.tail.foreach { msg =>
           currentState = currentState.addMessage(msg)

--- a/src/main/scala/org/llm4s/szork/game/GameTools.scala
+++ b/src/main/scala/org/llm4s/szork/game/GameTools.scala
@@ -11,6 +11,13 @@ object GameTools {
   // Mutable inventory storage (in a real app, this would be persisted)
   private val playerInventory = mutable.ListBuffer[String]()
 
+  // Unwrap a tool built via buildSafe(); a Left here is a static definition error.
+  private def orThrow[T, R](result: org.llm4s.types.Result[ToolFunction[T, R]]): ToolFunction[T, R] =
+    result match {
+      case Right(tool) => tool
+      case Left(error) => throw new IllegalStateException(s"Failed to build tool: ${error.message}")
+    }
+
   // Define result types
   case class InventoryListResult(
     inventory: List[String],
@@ -55,11 +62,12 @@ object GameTools {
     Right(result)
   }
 
-  val listInventoryTool = ToolBuilder[Map[String, Any], InventoryListResult](
-    "list_inventory",
-    "List all items currently in the player's inventory",
-    listInventorySchema
-  ).withHandler(listInventoryHandler).build()
+  val listInventoryTool = orThrow(
+    ToolBuilder[Map[String, Any], InventoryListResult](
+      "list_inventory",
+      "List all items currently in the player's inventory",
+      listInventorySchema
+    ).withHandler(listInventoryHandler).buildSafe())
 
   /** Tool to add an item to the player's inventory
     */
@@ -96,11 +104,12 @@ object GameTools {
       }
     }
 
-  val addInventoryItemTool = ToolBuilder[Map[String, Any], InventoryModifyResult](
-    "add_inventory_item",
-    "Add a new item to the player's inventory",
-    addInventorySchema
-  ).withHandler(addInventoryHandler).build()
+  val addInventoryItemTool = orThrow(
+    ToolBuilder[Map[String, Any], InventoryModifyResult](
+      "add_inventory_item",
+      "Add a new item to the player's inventory",
+      addInventorySchema
+    ).withHandler(addInventoryHandler).buildSafe())
 
   /** Tool to remove an item from the player's inventory
     */
@@ -137,11 +146,12 @@ object GameTools {
       }
     }
 
-  val removeInventoryItemTool = ToolBuilder[Map[String, Any], InventoryModifyResult](
-    "remove_inventory_item",
-    "Remove an item from the player's inventory",
-    removeInventorySchema
-  ).withHandler(removeInventoryHandler).build()
+  val removeInventoryItemTool = orThrow(
+    ToolBuilder[Map[String, Any], InventoryModifyResult](
+      "remove_inventory_item",
+      "Remove an item from the player's inventory",
+      removeInventorySchema
+    ).withHandler(removeInventoryHandler).buildSafe())
 
   /** Get all game tools for the ToolRegistry
     */

--- a/src/main/scala/org/llm4s/szork/media/ImageGeneration.scala
+++ b/src/main/scala/org/llm4s/szork/media/ImageGeneration.scala
@@ -13,6 +13,17 @@ class ImageGeneration {
   private val config = SzorkConfig.instance
 
   // Configure image generation provider based on configuration
+  // LLM4S image client factories now return Either[ImageGenerationError, ImageGenerationClient].
+  // Unwrap into an Option, logging (and disabling images) on construction failure.
+  private def unwrapClient(result: Either[imagegeneration.ImageGenerationError, imagegeneration.ImageGenerationClient])
+    : Option[imagegeneration.ImageGenerationClient] =
+    result match {
+      case Right(client) => Some(client)
+      case Left(error) =>
+        logger.error(s"Failed to create image generation client: ${error.message}")
+        None
+    }
+
   private val (imageClientOpt, providerName) =
     if (!config.imageGenerationEnabled) {
       logger.info("Image generation is disabled")
@@ -37,7 +48,7 @@ class ImageGeneration {
             case _ => "runwayml/stable-diffusion-v1-5"
           }
           logger.info(s"Using HuggingFace for image generation with model: $model")
-          (Some(imagegeneration.ImageGeneration.huggingFaceClient(hfKey, model)), s"HuggingFace ($model)")
+          (unwrapClient(imagegeneration.ImageGeneration.huggingFaceClient(hfKey, model)), s"HuggingFace ($model)")
 
         case ImageProvider.OpenAIDalle3 =>
           val openAIKey = EnvLoader
@@ -46,7 +57,7 @@ class ImageGeneration {
               throw new IllegalStateException("Image provider set to OpenAI DALL-E 3 but OPENAI_API_KEY not found")
             )
           logger.info("Using OpenAI DALL-E 3 for image generation")
-          (Some(imagegeneration.ImageGeneration.openAIClient(openAIKey, "dall-e-3")), "OpenAI DALL-E 3")
+          (unwrapClient(imagegeneration.ImageGeneration.openAIClient(openAIKey, "dall-e-3")), "OpenAI DALL-E 3")
 
         case ImageProvider.OpenAIDalle2 =>
           val openAIKey = EnvLoader
@@ -55,7 +66,7 @@ class ImageGeneration {
               throw new IllegalStateException("Image provider set to OpenAI DALL-E 2 but OPENAI_API_KEY not found")
             )
           logger.info("Using OpenAI DALL-E 2 for image generation")
-          (Some(imagegeneration.ImageGeneration.openAIClient(openAIKey, "dall-e-2")), "OpenAI DALL-E 2")
+          (unwrapClient(imagegeneration.ImageGeneration.openAIClient(openAIKey, "dall-e-2")), "OpenAI DALL-E 2")
 
         case ImageProvider.LocalStableDiffusion =>
           val baseUrl = EnvLoader
@@ -67,7 +78,7 @@ class ImageGeneration {
             .orElse(EnvLoader.get("SD_API_KEY"))
           logger.info(s"Using Local Stable Diffusion for image generation at: $baseUrl")
           (
-            Some(imagegeneration.ImageGeneration.stableDiffusionClient(baseUrl, apiKey)),
+            unwrapClient(imagegeneration.ImageGeneration.stableDiffusionClient(baseUrl, apiKey)),
             s"Local Stable Diffusion ($baseUrl)")
       }
     }

--- a/src/main/scala/org/llm4s/szork/persistence/StepData.scala
+++ b/src/main/scala/org/llm4s/szork/persistence/StepData.scala
@@ -153,7 +153,7 @@ object StepData {
       executionTimeMs = executionTimeMs
     )
 
-    val response = scene.map(SceneResponse)
+    val response = scene.map(SceneResponse.apply)
 
     StepData(
       metadata = metadata,


### PR DESCRIPTION
## Summary

Ports szork from **Scala 2.13.16** to **Scala 3.7.1** on the latest llm4s release, **0.3.2** (the Scala 3-default build, with a 2.13 backport pathway).

## Build changes
- `scalaVersion` `2.13.16` → **`3.7.1`**
- llm4s `core` `0.2.5` → **`0.3.2`**; `anthropic-java` `2.2.0` → `2.11.1` (matches llm4s's transitive dep)
- Scala 2.13 `-Wunused:*` flags → Scala 3 options (`-source:3.3`)
- scalafmt `runner.dialect` `scala213` → `scala3`

## llm4s 0.3.x API ports
The 0.3.x line changed several APIs vs szork's 0.2.5 baseline:
- **`SzorkConfig`** — `LLMConnect.getClient` now requires a `given ModelRegistryService`; wired from `ModelRegistryService.default()`.
- **`GameEngine`** — `agent.initialize` → `agent.initializeSafe` (returns `Result[AgentState]`, unwrapped at all sites); `agent.run(state, maxSteps, traceLogPath, debug)` → `agent.run(state, maxSteps, AgentContext(debug = true))`.
- **`ImageGeneration`** — image client factories now return `Either[ImageGenerationError, ImageGenerationClient]`; unwrapped via a helper that logs and disables images on failure.
- **`GameTools`** — `ToolBuilder.build()` (deprecated since 0.2.9) → `buildSafe()`.
- Scala 3 eta-expansion: `scene.map(SceneResponse)` → `.map(SceneResponse.apply)`.

`StreamingAgent` (extends `Agent`, uses `runStep`/`streamComplete`) compiled unchanged — those APIs are stable.

## Verification
`sbt clean compile Test/compile test`:
- 44 main + 14 test sources compile under Scala 3.7.1, **zero warnings, zero errors**
- All **46 tests pass** (`GameEngineUnitSpec`, `GameEngineValidationSpec`, `StepPersistenceSpec`)
- Pre-commit hook (scalafmt check + compile with fatal warnings) passes