### PR TITLE
[design] Extract media network config

### DIFF
--- a/.forge/specs/extract-media-network-config/decomposition.md
+++ b/.forge/specs/extract-media-network-config/decomposition.md
@@ -1,0 +1,22 @@
+# Extract media network config
+
+> Feature **extract-media-network-config** — base branch `main`,
+> branch prefix `forge`.
+
+## Pieces
+
+<!-- forge:order-start -->
+1. <!-- forge:piece p1 -->**p1: Extract media network timeouts into MediaNetworkConfig**<!-- /forge:piece -->
+   <!-- forge:editable-summary p1 -->
+   Add env-overridable MediaNetworkConfig and route the five duplicated connect/read timeout sites in TextToSpeech, SpeechToText, and MusicGeneration through it.
+   <!-- /forge:editable-summary -->
+   <!-- forge:status p1 -->`pending`<!-- /forge:status -->
+
+<!-- forge:order-end -->
+
+---
+
+*Rendered by [Forge](https://github.com/anthropics/forge) from
+`manifest.json`. Edit a piece summary or reorder the list between the
+`forge:order-start` / `forge:order-end` markers above, then run
+`forge reconcile extract-media-network-config` to import the change.*

--- a/.forge/specs/extract-media-network-config/design.md
+++ b/.forge/specs/extract-media-network-config/design.md
@@ -1,0 +1,106 @@
+# extract-media-network-config
+
+## Problem
+
+The three media HTTP clients each hardcode the same network timeout pair
+inline at every request site:
+
+- `media/TextToSpeech.scala` — `synthesize()` POST to OpenAI:
+  `readTimeout = 30000`, `connectTimeout = 10000` (~lines 37-38).
+- `media/SpeechToText.scala` — `transcribe()` POST to OpenAI:
+  `readTimeout = 30000`, `connectTimeout = 10000` (~lines 32-33).
+- `media/MusicGeneration.scala` — `generateMusicWithCache()` create-prediction
+  POST to Replicate: `readTimeout = 30000`, `connectTimeout = 10000`
+  (~lines 215-216).
+- `media/MusicGeneration.scala` — `pollPrediction()` GET to Replicate:
+  `readTimeout = 30000`, `connectTimeout = 10000` (~lines 277-278).
+- `media/MusicGeneration.scala` — `downloadAndEncodeAudio()` raw
+  `URLConnection`: `setConnectTimeout(10000)`, `setReadTimeout(30000)`
+  (~lines 325-326).
+
+The same two magic numbers (`30000` read, `10000` connect) are copy-pasted
+across five sites in three files. There is no single place to see or change
+the media network timeouts, and the values cannot be tuned per deployment
+(e.g. a slow local model server or a flaky network) without editing source
+in multiple spots that will drift apart.
+
+## Approach
+
+Backend de-duplication plus light configurability, scoped to the media
+HTTP timeouts only. Mirrors the existing `image-creds-dedup` refactor in
+style (small surgical change, injectable `ConfigReader` for testing,
+env-overridable defaults).
+
+Add a small `MediaNetworkConfig` case class in the `api` package
+(`api/MediaNetworkConfig.scala`, next to `SzorkConfig`):
+
+```scala
+case class MediaNetworkConfig(
+  connectTimeoutMs: Int = 10000,
+  readTimeoutMs: Int = 30000
+)
+```
+
+with a loader and a lazily-evaluated shared instance, following the exact
+shape of `SzorkConfig`:
+
+- `MediaNetworkConfig.load(reader: ConfigReader = EnvLoader): MediaNetworkConfig`
+  reads two env vars, falling back to the current literals on absent or
+  unparseable values:
+  - `SZORK_MEDIA_CONNECT_TIMEOUT_MS` → `connectTimeoutMs` (default `10000`).
+  - `SZORK_MEDIA_READ_TIMEOUT_MS` → `readTimeoutMs` (default `30000`).
+  - Parsing uses `Try(_.toInt).toOption`; an unparseable value uses the
+    default (consistent with how `SzorkConfig` loads `SZORK_PORT`).
+- `lazy val instance: MediaNetworkConfig = load()` — the shared production
+  value, matching `SzorkConfig.instance`.
+
+Then route every timeout site through it:
+
+- `TextToSpeech` and `SpeechToText` each hold a
+  `private val net = MediaNetworkConfig.instance` and pass
+  `connectTimeout = net.connectTimeoutMs`, `readTimeout = net.readTimeoutMs`
+  to their `requests` call.
+- `MusicGeneration` does the same for both the create-prediction POST and
+  the `pollPrediction` GET, and uses `net.connectTimeoutMs` /
+  `net.readTimeoutMs` in `downloadAndEncodeAudio`'s
+  `setConnectTimeout` / `setReadTimeout`.
+
+The defaults equal the current literals, so default behaviour is
+byte-for-byte unchanged.
+
+## Testing
+
+Add one ScalaTest spec (`MediaNetworkConfigSpec.scala`, matching the
+existing suite) that drives `MediaNetworkConfig.load` with a fake
+`ConfigReader`:
+
+- Absent env vars ⇒ defaults `connectTimeoutMs = 10000`,
+  `readTimeoutMs = 30000`.
+- Both env vars set to valid integers ⇒ parsed values are used.
+- An unparseable value (e.g. `"abc"`) ⇒ falls back to the default for that
+  field, independently of the other.
+
+## Non-goals
+
+- Music poll settings (`maxAttempts = 30`, the `Thread.sleep(1000)` poll
+  interval) are **not** extracted — timeouts only.
+- The service base URLs (`api.openai.com`, `api.replicate.com`) and the
+  Replicate model version string are **not** extracted; they are unique
+  per service, not duplicated, and out of scope for this pass.
+- No change to credentials, retry/`retryable` logic, request bodies,
+  headers, or any user-visible behaviour.
+- No change to default timeout values — only where they are defined.
+
+## Decisions
+
+- Timeouts only, env-overridable with defaults, in a dedicated
+  `MediaNetworkConfig` type. (Proposed alternatives — bundling poll
+  settings/URLs, constants-only with no env overrides, or adding fields to
+  `SzorkConfig` — were set aside in favour of the tightest match to the
+  feature name and the existing config conventions.)
+- The new type lives in the `api` package beside `SzorkConfig`, where the
+  other config types and env-loading live, rather than in the `media`
+  package.
+- Injectable `ConfigReader` defaulting to `EnvLoader`, exactly as
+  `image-creds-dedup` did, so the loader is unit-testable without touching
+  process env. Production call sites use `MediaNetworkConfig.instance`.

--- a/.forge/specs/extract-media-network-config/manifest.json
+++ b/.forge/specs/extract-media-network-config/manifest.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "featureId": "extract-media-network-config",
+  "title": "Extract media network config",
+  "baseBranch": "main",
+  "branchPrefix": "forge",
+  "mode": "claude-driver",
+  "designPr": null,
+  "pieces": [
+    {
+      "id": "p1",
+      "order": 1,
+      "title": "Extract media network timeouts into MediaNetworkConfig",
+      "summary": "Add env-overridable MediaNetworkConfig and route the five duplicated connect/read timeout sites in TextToSpeech, SpeechToText, and MusicGeneration through it.",
+      "specPath": "pieces/p1.md",
+      "acceptanceHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "status": "pending",
+      "baseSha": null,
+      "prNumber": null,
+      "mergeCommit": null,
+      "mergedAt": null,
+      "attempts": 0
+    }
+  ]
+}

--- a/.forge/specs/extract-media-network-config/pieces/p1.md
+++ b/.forge/specs/extract-media-network-config/pieces/p1.md
@@ -1,0 +1,68 @@
+# p1: Extract media network timeouts into MediaNetworkConfig
+
+## Summary
+
+Introduce a `MediaNetworkConfig` (connect/read timeouts, env-overridable
+with the current defaults) and route the five duplicated timeout sites in
+`TextToSpeech`, `SpeechToText`, and `MusicGeneration` through it.
+
+## Context
+
+The connect/read timeout pair (`connectTimeout = 10000`,
+`readTimeout = 30000`) is hardcoded at five sites across three files:
+
+- `media/TextToSpeech.scala` — `synthesize()` POST.
+- `media/SpeechToText.scala` — `transcribe()` POST.
+- `media/MusicGeneration.scala` — create-prediction POST in
+  `generateMusicWithCache()`.
+- `media/MusicGeneration.scala` — `pollPrediction()` GET.
+- `media/MusicGeneration.scala` — `downloadAndEncodeAudio()`
+  `URLConnection` (`setConnectTimeout`/`setReadTimeout`).
+
+## Changes
+
+1. Add `api/MediaNetworkConfig.scala`:
+   - `case class MediaNetworkConfig(connectTimeoutMs: Int = 10000,
+     readTimeoutMs: Int = 30000)`.
+   - `object MediaNetworkConfig` with:
+     - `def load(reader: ConfigReader = EnvLoader): MediaNetworkConfig`
+       reading `SZORK_MEDIA_CONNECT_TIMEOUT_MS` and
+       `SZORK_MEDIA_READ_TIMEOUT_MS`, parsing with `Try(_.toInt).toOption`,
+       falling back to the field default when absent or unparseable.
+     - `lazy val instance: MediaNetworkConfig = load()`.
+2. In `TextToSpeech`, `SpeechToText`, and `MusicGeneration`, reference
+   `MediaNetworkConfig.instance` and substitute its `connectTimeoutMs` /
+   `readTimeoutMs` for every literal `10000` / `30000` timeout, at all five
+   sites listed above.
+3. Add `MediaNetworkConfigSpec.scala` covering the loader.
+
+## Acceptance criteria
+
+- [ ] `MediaNetworkConfig` exists in the `api` package with `Int` fields
+      `connectTimeoutMs` (default `10000`) and `readTimeoutMs`
+      (default `30000`).
+- [ ] `MediaNetworkConfig.load()` with no relevant env vars returns
+      `connectTimeoutMs = 10000` and `readTimeoutMs = 30000`.
+- [ ] `MediaNetworkConfig.load(reader)` with a fake `ConfigReader`
+      supplying valid integers for `SZORK_MEDIA_CONNECT_TIMEOUT_MS` and
+      `SZORK_MEDIA_READ_TIMEOUT_MS` returns those parsed values.
+- [ ] `MediaNetworkConfig.load(reader)` with an unparseable value for a
+      field falls back to that field's default, independently of the other
+      field.
+- [ ] `MediaNetworkConfig.instance` is a `lazy val` returning `load()`.
+- [ ] All five timeout sites (TextToSpeech POST, SpeechToText POST,
+      MusicGeneration create-prediction POST, `pollPrediction` GET, and
+      `downloadAndEncodeAudio` `URLConnection`) read their connect/read
+      timeouts from `MediaNetworkConfig`.
+- [ ] No literal `30000` or `10000` timeout value remains in
+      `TextToSpeech.scala`, `SpeechToText.scala`, or `MusicGeneration.scala`.
+- [ ] A `MediaNetworkConfigSpec` ScalaTest spec exists and exercises the
+      default, override, and unparseable-fallback cases.
+- [ ] `sbt compile` and `sbt test` pass; no behaviour change with default
+      configuration (defaults equal the previous literals).
+
+## Out of scope
+
+- Music poll settings (`maxAttempts`, the 1000ms `Thread.sleep`).
+- Service base URLs and the Replicate model version string.
+- Credentials, headers, request bodies, and retry/`retryable` logic.


### PR DESCRIPTION
# extract-media-network-config

## Problem

The three media HTTP clients each hardcode the same network timeout pair
inline at every request site:

- `media/TextToSpeech.scala` — `synthesize()` POST to OpenAI:
  `readTimeout = 30000`, `connectTimeout = 10000` (~lines 37-38).
- `media/SpeechToText.scala` — `transcribe()` POST to OpenAI:
  `readTimeout = 30000`, `connectTimeout = 10000` (~lines 32-33).
- `media/MusicGeneration.scala` — `generateMusicWithCache()` create-prediction
  POST to Replicate: `readTimeout = 30000`, `connectTimeout = 10000`
  (~lines 215-216).
- `media/MusicGeneration.scala` — `pollPrediction()` GET to Replicate:
  `readTimeout = 30000`, `connectTimeout = 10000` (~lines 277-278).
- `media/MusicGeneration.scala` — `downloadAndEncodeAudio()` raw
  `URLConnection`: `setConnectTimeout(10000)`, `setReadTimeout(30000)`
  (~lines 325-326).

The same two magic numbers (`30000` read, `10000` connect) are copy-pasted
across five sites in three files. There is no single place to see or change
the media network timeouts, and the values cannot be tuned per deployment
(e.g. a slow local model server or a flaky network) without editing source
in multiple spots that will drift apart.

## Approach

Backend de-duplication plus light configurability, scoped to the media
HTTP timeouts only. Mirrors the existing `image-creds-dedup` refactor in
style (small surgical change, injectable `ConfigReader` for testing,
env-overridable defaults).

Add a small `MediaNetworkConfig` case class in the `api` package
(`api/MediaNetworkConfig.scala`, next to `SzorkConfig`):

```scala
case class MediaNetworkConfig(
  connectTimeoutMs: Int = 10000,
  readTimeoutMs: Int = 30000
)
```

with a loader and a lazily-evaluated shared instance, following the exact
shape of `SzorkConfig`:

- `MediaNetworkConfig.load(reader: ConfigReader = EnvLoader): MediaNetworkConfig`
  reads two env vars, falling back to the current literals on absent or
  unparseable values:
  - `SZORK_MEDIA_CONNECT_TIMEOUT_MS` → `connectTimeoutMs` (default `10000`).
  - `SZORK_MEDIA_READ_TIMEOUT_MS` → `readTimeoutMs` (default `30000`).
  - Parsing uses `Try(_.toInt).toOption`; an unparseable value uses the
    default (consistent with how `SzorkConfig` loads `SZORK_PORT`).
- `lazy val instance: MediaNetworkConfig = load()` — the shared production
  value, matching `SzorkConfig.instance`.

Then route every timeout site through it:

- `TextToSpeech` and `SpeechToText` each hold a
  `private val net = MediaNetworkConfig.instance` and pass
  `connectTimeout = net.connectTimeoutMs`, `readTimeout = net.readTimeoutMs`
  to their `requests` call.
- `MusicGeneration` does the same for both the create-prediction POST and
  the `pollPrediction` GET, and uses `net.connectTimeoutMs` /
  `net.readTimeoutMs` in `downloadAndEncodeAudio`'s
  `setConnectTimeout` / `setReadTimeout`.

The defaults equal the current literals, so default behaviour is
byte-for-byte unchanged.

## Testing

Add one ScalaTest spec (`MediaNetworkConfigSpec.scala`, matching the
existing suite) that drives `MediaNetworkConfig.load` with a fake
`ConfigReader`:

- Absent env vars ⇒ defaults `connectTimeoutMs = 10000`,
  `readTimeoutMs = 30000`.
- Both env vars set to valid integers ⇒ parsed values are used.
- An unparseable value (e.g. `"abc"`) ⇒ falls back to the default for that
  field, independently of the other.

## Non-goals

- Music poll settings (`maxAttempts = 30`, the `Thread.sleep(1000)` poll
  interval) are **not** extracted — timeouts only.
- The service base URLs (`api.openai.com`, `api.replicate.com`) and the
  Replicate model version string are **not** extracted; they are unique
  per service, not duplicated, and out of scope for this pass.
- No change to credentials, retry/`retryable` logic, request bodies,
  headers, or any user-visible behaviour.
- No change to default timeout values — only where they are defined.

## Decisions

- Timeouts only, env-overridable with defaults, in a dedicated
  `MediaNetworkConfig` type. (Proposed alternatives — bundling poll
  settings/URLs, constants-only with no env overrides, or adding fields to
  `SzorkConfig` — were set aside in favour of the tightest match to the
  feature name and the existing config conventions.)
- The new type lives in the `api` package beside `SzorkConfig`, where the
  other config types and env-loading live, rather than in the `media`
  package.
- Injectable `ConfigReader` defaulting to `EnvLoader`, exactly as
  `image-creds-dedup` did, so the loader is unit-testable without touching
  process env. Production call sites use `MediaNetworkConfig.instance`.
