### PR TITLE
Extract media network timeouts into MediaNetworkConfig

### DIFF
--- a/.forge/specs/extract-media-network-config/decomposition.md
+++ b/.forge/specs/extract-media-network-config/decomposition.md
@@ -2,6 +2,7 @@
 
 > Feature **extract-media-network-config** — base branch `main`,
 > branch prefix `forge`.
+> Design PR: #14
 
 ## Pieces
 
@@ -10,7 +11,7 @@
    <!-- forge:editable-summary p1 -->
    Add env-overridable MediaNetworkConfig and route the five duplicated connect/read timeout sites in TextToSpeech, SpeechToText, and MusicGeneration through it.
    <!-- /forge:editable-summary -->
-   <!-- forge:status p1 -->`pending`<!-- /forge:status -->
+   <!-- forge:status p1 -->`in progress`<!-- /forge:status -->
 
 <!-- forge:order-end -->
 

--- a/.forge/specs/extract-media-network-config/manifest.json
+++ b/.forge/specs/extract-media-network-config/manifest.json
@@ -5,7 +5,7 @@
   "baseBranch": "main",
   "branchPrefix": "forge",
   "mode": "claude-driver",
-  "designPr": null,
+  "designPr": 14,
   "pieces": [
     {
       "id": "p1",
@@ -14,8 +14,8 @@
       "summary": "Add env-overridable MediaNetworkConfig and route the five duplicated connect/read timeout sites in TextToSpeech, SpeechToText, and MusicGeneration through it.",
       "specPath": "pieces/p1.md",
       "acceptanceHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-      "status": "pending",
-      "baseSha": null,
+      "status": "in_progress",
+      "baseSha": "e91463acf1d9ad426f5a01a5e685d3bda9ee562c",
       "prNumber": null,
       "mergeCommit": null,
       "mergedAt": null,

--- a/.forge/specs/extract-media-network-config/manifest.json
+++ b/.forge/specs/extract-media-network-config/manifest.json
@@ -19,7 +19,7 @@
       "prNumber": 15,
       "mergeCommit": null,
       "mergedAt": null,
-      "attempts": 1
+      "attempts": 2
     }
   ]
 }

--- a/.forge/specs/extract-media-network-config/manifest.json
+++ b/.forge/specs/extract-media-network-config/manifest.json
@@ -16,10 +16,10 @@
       "acceptanceHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
       "status": "in_progress",
       "baseSha": "e91463acf1d9ad426f5a01a5e685d3bda9ee562c",
-      "prNumber": null,
+      "prNumber": 15,
       "mergeCommit": null,
       "mergedAt": null,
-      "attempts": 0
+      "attempts": 1
     }
   ]
 }

--- a/.forge/specs/extract-media-network-config/pieces/p1.failures.md
+++ b/.forge/specs/extract-media-network-config/pieces/p1.failures.md
@@ -1,0 +1,12 @@
+# Piece p1 — failures to address (PR #15)
+
+These CI checks on the piece's PR did not pass (`gh pr checks`):
+
+```
+backend	fail	1m42s	https://github.com/llm4s/szork/actions/runs/26786101936/job/78962117741	
+frontend	pass	30s	https://github.com/llm4s/szork/actions/runs/26786101936/job/78962117748
+```
+
+Make the smallest change that makes the failing check(s) pass. For a formatting
+check, run the project's formatter on the changed files (a targeted format is
+fine — do NOT run the full test suite). Then stop; Forge commits and re-runs CI.

--- a/.forge/specs/extract-media-network-config/pieces/p1.failures.md
+++ b/.forge/specs/extract-media-network-config/pieces/p1.failures.md
@@ -3,8 +3,7 @@
 These CI checks on the piece's PR did not pass (`gh pr checks`):
 
 ```
-backend	fail	1m42s	https://github.com/llm4s/szork/actions/runs/26786101936/job/78962117741	
-frontend	pass	30s	https://github.com/llm4s/szork/actions/runs/26786101936/job/78962117748
+
 ```
 
 Make the smallest change that makes the failing check(s) pass. For a formatting

--- a/src/main/scala/org/llm4s/szork/api/MediaNetworkConfig.scala
+++ b/src/main/scala/org/llm4s/szork/api/MediaNetworkConfig.scala
@@ -5,8 +5,8 @@ import scala.util.Try
 
 /** Network timeouts shared by the media HTTP clients (TTS, STT, music).
   *
-  * Defaults equal the historical inline literals, so default behaviour is
-  * unchanged. Both values are env-overridable for per-deployment tuning.
+  * Defaults equal the historical inline literals, so default behaviour is unchanged. Both values are env-overridable
+  * for per-deployment tuning.
   */
 case class MediaNetworkConfig(
   connectTimeoutMs: Int = 10000,

--- a/src/main/scala/org/llm4s/szork/api/MediaNetworkConfig.scala
+++ b/src/main/scala/org/llm4s/szork/api/MediaNetworkConfig.scala
@@ -1,0 +1,37 @@
+package org.llm4s.szork.api
+
+import org.llm4s.config.{ConfigReader, EnvLoader}
+import scala.util.Try
+
+/** Network timeouts shared by the media HTTP clients (TTS, STT, music).
+  *
+  * Defaults equal the historical inline literals, so default behaviour is
+  * unchanged. Both values are env-overridable for per-deployment tuning.
+  */
+case class MediaNetworkConfig(
+  connectTimeoutMs: Int = 10000,
+  readTimeoutMs: Int = 30000
+)
+
+object MediaNetworkConfig {
+  lazy val instance: MediaNetworkConfig = load()
+
+  def load(reader: ConfigReader = EnvLoader): MediaNetworkConfig = {
+    val defaults = MediaNetworkConfig()
+
+    val connectTimeoutMs = reader
+      .get("SZORK_MEDIA_CONNECT_TIMEOUT_MS")
+      .flatMap(v => Try(v.toInt).toOption)
+      .getOrElse(defaults.connectTimeoutMs)
+
+    val readTimeoutMs = reader
+      .get("SZORK_MEDIA_READ_TIMEOUT_MS")
+      .flatMap(v => Try(v.toInt).toOption)
+      .getOrElse(defaults.readTimeoutMs)
+
+    MediaNetworkConfig(
+      connectTimeoutMs = connectTimeoutMs,
+      readTimeoutMs = readTimeoutMs
+    )
+  }
+}

--- a/src/main/scala/org/llm4s/szork/media/MusicGeneration.scala
+++ b/src/main/scala/org/llm4s/szork/media/MusicGeneration.scala
@@ -5,6 +5,7 @@ import org.llm4s.szork.error.ErrorHandling._
 import org.slf4j.{Logger, LoggerFactory}
 import requests._
 import org.llm4s.config.EnvLoader
+import org.llm4s.szork.api.MediaNetworkConfig
 import java.util.Base64
 import ujson._
 import java.io.ByteArrayOutputStream
@@ -12,6 +13,7 @@ import java.net.URI
 
 class MusicGeneration {
   private implicit val logger: Logger = LoggerFactory.getLogger(getClass.getSimpleName)
+  private val net = MediaNetworkConfig.instance
   private val replicateApiKey =
     EnvLoader.get("REPLICATE_API_KEY").filter(key => key.nonEmpty && !key.contains("YOUR_REPLICATE_API_KEY"))
 
@@ -212,8 +214,8 @@ class MusicGeneration {
             "classifier_free_guidance" -> mood.cfGuidance
           )
         ).toString,
-        readTimeout = 30000,
-        connectTimeout = 10000
+        readTimeout = net.readTimeoutMs,
+        connectTimeout = net.connectTimeoutMs
       )
 
       if (createResponse.statusCode != 201) {
@@ -274,8 +276,8 @@ class MusicGeneration {
       val response = get(
         s"https://api.replicate.com/v1/predictions/$predictionId",
         headers = Map("Authorization" -> s"Bearer ${replicateApiKey.get}"),
-        readTimeout = 30000,
-        connectTimeout = 10000
+        readTimeout = net.readTimeoutMs,
+        connectTimeout = net.connectTimeoutMs
       )
 
       if (response.statusCode == 200) {
@@ -322,8 +324,8 @@ class MusicGeneration {
       val url = uri.toURL()
       val connection = url.openConnection()
       try {
-        connection.setConnectTimeout(10000)
-        connection.setReadTimeout(30000)
+        connection.setConnectTimeout(net.connectTimeoutMs)
+        connection.setReadTimeout(net.readTimeoutMs)
       } catch { case _: Throwable => () }
       val inputStream = connection.getInputStream
 

--- a/src/main/scala/org/llm4s/szork/media/SpeechToText.scala
+++ b/src/main/scala/org/llm4s/szork/media/SpeechToText.scala
@@ -5,11 +5,13 @@ import org.llm4s.szork.error.ErrorHandling._
 import org.slf4j.{Logger, LoggerFactory}
 import requests._
 import org.llm4s.config.EnvLoader
+import org.llm4s.szork.api.MediaNetworkConfig
 import java.io.File
 import java.nio.file.Files
 
 class SpeechToText {
   private implicit val logger: Logger = LoggerFactory.getLogger(getClass.getSimpleName)
+  private val net = MediaNetworkConfig.instance
   private val apiKey = EnvLoader
     .get("OPENAI_API_KEY")
     .getOrElse(
@@ -29,8 +31,8 @@ class SpeechToText {
           MultiItem("file", audioFile, audioFile.getName),
           MultiItem("model", "whisper-1")
         ),
-        readTimeout = 30000,
-        connectTimeout = 10000
+        readTimeout = net.readTimeoutMs,
+        connectTimeout = net.connectTimeoutMs
       )
 
       if (response.statusCode == 200) {

--- a/src/main/scala/org/llm4s/szork/media/TextToSpeech.scala
+++ b/src/main/scala/org/llm4s/szork/media/TextToSpeech.scala
@@ -6,9 +6,11 @@ import org.llm4s.config.EnvLoader
 import java.util.Base64
 import org.llm4s.szork.error._
 import org.llm4s.szork.error.ErrorHandling._
+import org.llm4s.szork.api.MediaNetworkConfig
 
 class TextToSpeech {
   private implicit val logger: Logger = LoggerFactory.getLogger(getClass.getSimpleName)
+  private val net = MediaNetworkConfig.instance
   private val apiKey = EnvLoader
     .get("OPENAI_API_KEY")
     .getOrElse(
@@ -34,8 +36,8 @@ class TextToSpeech {
             "response_format" -> "mp3"
           )
           .toString,
-        readTimeout = 30000,
-        connectTimeout = 10000
+        readTimeout = net.readTimeoutMs,
+        connectTimeout = net.connectTimeoutMs
       )
 
       if (response.statusCode == 200) {

--- a/src/test/scala/org/llm4s/szork/MediaNetworkConfigSpec.scala
+++ b/src/test/scala/org/llm4s/szork/MediaNetworkConfigSpec.scala
@@ -1,0 +1,59 @@
+package org.llm4s.szork
+
+import org.llm4s.config.ConfigReader
+import org.llm4s.szork.api.MediaNetworkConfig
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class MediaNetworkConfigSpec extends AnyFunSuite with Matchers {
+
+  /** A deterministic in-memory ConfigReader backed by a Map. */
+  private final case class FakeReader(values: Map[String, String]) extends ConfigReader {
+    override def get(key: String): Option[String] = values.get(key)
+  }
+
+  test("load with no relevant env vars returns the defaults") {
+    val config = MediaNetworkConfig.load(FakeReader(Map.empty))
+    config.connectTimeoutMs shouldBe 10000
+    config.readTimeoutMs shouldBe 30000
+  }
+
+  test("load uses parsed values when both env vars supply valid integers") {
+    val reader = FakeReader(
+      Map(
+        "SZORK_MEDIA_CONNECT_TIMEOUT_MS" -> "1234",
+        "SZORK_MEDIA_READ_TIMEOUT_MS" -> "56789"
+      ))
+    val config = MediaNetworkConfig.load(reader)
+    config.connectTimeoutMs shouldBe 1234
+    config.readTimeoutMs shouldBe 56789
+  }
+
+  test("load falls back to the connect default when connect value is unparseable") {
+    val reader = FakeReader(
+      Map(
+        "SZORK_MEDIA_CONNECT_TIMEOUT_MS" -> "abc",
+        "SZORK_MEDIA_READ_TIMEOUT_MS" -> "56789"
+      ))
+    val config = MediaNetworkConfig.load(reader)
+    config.connectTimeoutMs shouldBe 10000
+    config.readTimeoutMs shouldBe 56789
+  }
+
+  test("load falls back to the read default when read value is unparseable") {
+    val reader = FakeReader(
+      Map(
+        "SZORK_MEDIA_CONNECT_TIMEOUT_MS" -> "1234",
+        "SZORK_MEDIA_READ_TIMEOUT_MS" -> "xyz"
+      ))
+    val config = MediaNetworkConfig.load(reader)
+    config.connectTimeoutMs shouldBe 1234
+    config.readTimeoutMs shouldBe 30000
+  }
+
+  test("default case class fields equal the historical literals") {
+    val config = MediaNetworkConfig()
+    config.connectTimeoutMs shouldBe 10000
+    config.readTimeoutMs shouldBe 30000
+  }
+}


### PR DESCRIPTION
# Extract media network timeouts into MediaNetworkConfig

> Piece **p1** of feature [Extract media network config](../specs/extract-media-network-config/design.md).
> Design PR: #14

## Summary

Add env-overridable MediaNetworkConfig and route the five duplicated connect/read timeout sites in TextToSpeech, SpeechToText, and MusicGeneration through it.

## Spec

# p1: Extract media network timeouts into MediaNetworkConfig

## Summary

Introduce a `MediaNetworkConfig` (connect/read timeouts, env-overridable
with the current defaults) and route the five duplicated timeout sites in
`TextToSpeech`, `SpeechToText`, and `MusicGeneration` through it.

## Context

The connect/read timeout pair (`connectTimeout = 10000`,
`readTimeout = 30000`) is hardcoded at five sites across three files:

- `media/TextToSpeech.scala` — `synthesize()` POST.
- `media/SpeechToText.scala` — `transcribe()` POST.
- `media/MusicGeneration.scala` — create-prediction POST in
  `generateMusicWithCache()`.
- `media/MusicGeneration.scala` — `pollPrediction()` GET.
- `media/MusicGeneration.scala` — `downloadAndEncodeAudio()`
  `URLConnection` (`setConnectTimeout`/`setReadTimeout`).

## Changes

1. Add `api/MediaNetworkConfig.scala`:
   - `case class MediaNetworkConfig(connectTimeoutMs: Int = 10000,
     readTimeoutMs: Int = 30000)`.
   - `object MediaNetworkConfig` with:
     - `def load(reader: ConfigReader = EnvLoader): MediaNetworkConfig`
       reading `SZORK_MEDIA_CONNECT_TIMEOUT_MS` and
       `SZORK_MEDIA_READ_TIMEOUT_MS`, parsing with `Try(_.toInt).toOption`,
       falling back to the field default when absent or unparseable.
     - `lazy val instance: MediaNetworkConfig = load()`.
2. In `TextToSpeech`, `SpeechToText`, and `MusicGeneration`, reference
   `MediaNetworkConfig.instance` and substitute its `connectTimeoutMs` /
   `readTimeoutMs` for every literal `10000` / `30000` timeout, at all five
   sites listed above.
3. Add `MediaNetworkConfigSpec.scala` covering the loader.

## Acceptance criteria

- [ ] `MediaNetworkConfig` exists in the `api` package with `Int` fields
      `connectTimeoutMs` (default `10000`) and `readTimeoutMs`
      (default `30000`).
- [ ] `MediaNetworkConfig.load()` with no relevant env vars returns
      `connectTimeoutMs = 10000` and `readTimeoutMs = 30000`.
- [ ] `MediaNetworkConfig.load(reader)` with a fake `ConfigReader`
      supplying valid integers for `SZORK_MEDIA_CONNECT_TIMEOUT_MS` and
      `SZORK_MEDIA_READ_TIMEOUT_MS` returns those parsed values.
- [ ] `MediaNetworkConfig.load(reader)` with an unparseable value for a
      field falls back to that field's default, independently of the other
      field.
- [ ] `MediaNetworkConfig.instance` is a `lazy val` returning `load()`.
- [ ] All five timeout sites (TextToSpeech POST, SpeechToText POST,
      MusicGeneration create-prediction POST, `pollPrediction` GET, and
      `downloadAndEncodeAudio` `URLConnection`) read their connect/read
      timeouts from `MediaNetworkConfig`.
- [ ] No literal `30000` or `10000` timeout value remains in
      `TextToSpeech.scala`, `SpeechToText.scala`, or `MusicGeneration.scala`.
- [ ] A `MediaNetworkConfigSpec` ScalaTest spec exists and exercises the
      default, override, and unparseable-fallback cases.
- [ ] `sbt compile` and `sbt test` pass; no behaviour change with default
      configuration (defaults equal the previous literals).

## Out of scope

- Music poll settings (`maxAttempts`, the 1000ms `Thread.sleep`).
- Service base URLs and the Replicate model version string.
- Credentials, headers, request bodies, and retry/`retryable` logic.


## Audit

Implemented by the Forge claude driver.

---

*Opened by [Forge](https://github.com/anthropics/forge). Reviewed by the cross-model reviewer; merged by a human after CI passes.*
