### PR TITLE
[design] music-poll-config

### DIFF
--- a/.forge/specs/music-poll-config/decomposition.md
+++ b/.forge/specs/music-poll-config/decomposition.md
@@ -1,0 +1,22 @@
+# music-poll-config
+
+> Feature **music-poll-config** — base branch `main`,
+> branch prefix `forge`.
+
+## Pieces
+
+<!-- forge:order-start -->
+1. <!-- forge:piece p1 -->**p1: Add MusicPollConfig and route pollPrediction through it**<!-- /forge:piece -->
+   <!-- forge:editable-summary p1 -->
+   Introduce env-overridable MusicPollConfig, route MusicGeneration.pollPrediction through it, and add MusicPollConfigSpec.
+   <!-- /forge:editable-summary -->
+   <!-- forge:status p1 -->`pending`<!-- /forge:status -->
+
+<!-- forge:order-end -->
+
+---
+
+*Rendered by [Forge](https://github.com/anthropics/forge) from
+`manifest.json`. Edit a piece summary or reorder the list between the
+`forge:order-start` / `forge:order-end` markers above, then run
+`forge reconcile music-poll-config` to import the change.*

--- a/.forge/specs/music-poll-config/design.md
+++ b/.forge/specs/music-poll-config/design.md
@@ -1,0 +1,48 @@
+# music-poll-config
+
+## Problem
+
+`MusicGeneration.pollPrediction`
+(`src/main/scala/org/llm4s/szork/media/MusicGeneration.scala`) hardcodes its
+polling behaviour:
+
+- `maxAttempts: Int = 30` (method default parameter)
+- `Thread.sleep(1000)` between polls (the "Wait 1 second before polling again" line)
+
+Neither value is configurable, so a deployment cannot tune how long Szork waits
+for a Replicate music prediction to finish.
+
+This mirrors the gap that `MediaNetworkConfig`
+(`src/main/scala/org/llm4s/szork/api/MediaNetworkConfig.scala`) already closed for
+the media HTTP connect/read timeouts.
+
+## Approach
+
+Add a small `MusicPollConfig` case class + companion in the `org.llm4s.szork.api`
+package, modelled exactly on `MediaNetworkConfig`:
+
+- Fields with defaults equal to the current literals:
+  - `maxAttempts: Int = 30`
+  - `pollIntervalMs: Int = 1000`
+- An env-overridable `load(reader: ConfigReader = EnvLoader)` reading
+  `SZORK_MUSIC_POLL_MAX_ATTEMPTS` and `SZORK_MUSIC_POLL_INTERVAL_MS` (each parsed
+  via `Try(_.toInt).toOption`, falling back to the defaults when absent or
+  unparseable), plus a `lazy val instance = load()`.
+- Route `MusicGeneration.pollPrediction` through `MusicPollConfig.instance`: the
+  `maxAttempts` default parameter becomes `MusicPollConfig.instance.maxAttempts`
+  and `Thread.sleep(1000)` becomes
+  `Thread.sleep(MusicPollConfig.instance.pollIntervalMs)`. Default behaviour is
+  unchanged (defaults equal the old literals).
+- A unit test `MusicPollConfigSpec` mirroring `MediaNetworkConfigSpec`: defaults
+  equal the historical literals, and the two env vars override (including
+  unparseable-value fallback).
+
+## Non-goals
+
+- No change to the polling logic itself, the HTTP client, or any other media class.
+- No change to `MediaNetworkConfig`.
+
+## Decisions
+
+Single piece **p1** — small, self-contained: add `MusicPollConfig`, route
+`pollPrediction` through it, add `MusicPollConfigSpec`.

--- a/.forge/specs/music-poll-config/manifest.json
+++ b/.forge/specs/music-poll-config/manifest.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "featureId": "music-poll-config",
+  "title": "music-poll-config",
+  "baseBranch": "main",
+  "branchPrefix": "forge",
+  "mode": "claude-driver",
+  "designPr": null,
+  "pieces": [
+    {
+      "id": "p1",
+      "order": 1,
+      "title": "Add MusicPollConfig and route pollPrediction through it",
+      "summary": "Introduce env-overridable MusicPollConfig, route MusicGeneration.pollPrediction through it, and add MusicPollConfigSpec.",
+      "specPath": "pieces/p1.md",
+      "acceptanceHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "status": "pending",
+      "baseSha": null,
+      "prNumber": null,
+      "mergeCommit": null,
+      "mergedAt": null,
+      "attempts": 0
+    }
+  ]
+}

--- a/.forge/specs/music-poll-config/pieces/p1.md
+++ b/.forge/specs/music-poll-config/pieces/p1.md
@@ -1,0 +1,57 @@
+# p1 — Add MusicPollConfig and route pollPrediction through it
+
+## Goal
+
+Make `MusicGeneration.pollPrediction`'s polling behaviour configurable via a new
+`MusicPollConfig`, modelled exactly on the existing `MediaNetworkConfig`. Default
+behaviour must be unchanged.
+
+## Changes
+
+### 1. New file: `src/main/scala/org/llm4s/szork/api/MusicPollConfig.scala`
+
+- Package `org.llm4s.szork.api`.
+- `case class MusicPollConfig(maxAttempts: Int = 30, pollIntervalMs: Int = 1000)`.
+- Companion `object MusicPollConfig` with:
+  - `lazy val instance: MusicPollConfig = load()`
+  - `def load(reader: ConfigReader = EnvLoader): MusicPollConfig` that reads
+    `SZORK_MUSIC_POLL_MAX_ATTEMPTS` for `maxAttempts` and
+    `SZORK_MUSIC_POLL_INTERVAL_MS` for `pollIntervalMs`, each parsed via
+    `Try(v.toInt).toOption` and falling back to the corresponding default when the
+    env var is absent or unparseable.
+- Use the same imports/structure as `MediaNetworkConfig`
+  (`org.llm4s.config.{ConfigReader, EnvLoader}`, `scala.util.Try`).
+
+### 2. Edit `src/main/scala/org/llm4s/szork/media/MusicGeneration.scala`
+
+- The `pollPrediction` method default parameter `maxAttempts: Int = 30` becomes
+  `maxAttempts: Int = MusicPollConfig.instance.maxAttempts`.
+- The `Thread.sleep(1000)` line becomes
+  `Thread.sleep(MusicPollConfig.instance.pollIntervalMs)`.
+- Add the import for `MusicPollConfig` (e.g. `import org.llm4s.szork.api.MusicPollConfig`).
+
+### 3. New test: `src/test/scala/org/llm4s/szork/MusicPollConfigSpec.scala`
+
+Mirror `MediaNetworkConfigSpec` (same `FakeReader` pattern, `AnyFunSuite` +
+`Matchers`).
+
+## Acceptance criteria
+
+- [ ] `MusicPollConfig()` (no-arg) yields `maxAttempts == 30` and `pollIntervalMs == 1000`.
+- [ ] `MusicPollConfig.load` with an empty reader returns `maxAttempts == 30`,
+      `pollIntervalMs == 1000`.
+- [ ] `MusicPollConfig.load` with `SZORK_MUSIC_POLL_MAX_ATTEMPTS=7` and
+      `SZORK_MUSIC_POLL_INTERVAL_MS=250` returns `maxAttempts == 7`,
+      `pollIntervalMs == 250`.
+- [ ] `MusicPollConfig.load` falls back to the `maxAttempts` default (30) when
+      `SZORK_MUSIC_POLL_MAX_ATTEMPTS` is unparseable (e.g. `"abc"`), while a valid
+      `SZORK_MUSIC_POLL_INTERVAL_MS` is still applied.
+- [ ] `MusicPollConfig.load` falls back to the `pollIntervalMs` default (1000) when
+      `SZORK_MUSIC_POLL_INTERVAL_MS` is unparseable, while a valid
+      `SZORK_MUSIC_POLL_MAX_ATTEMPTS` is still applied.
+- [ ] `MusicGeneration.pollPrediction` uses `MusicPollConfig.instance.maxAttempts`
+      as its default attempt cap and `MusicPollConfig.instance.pollIntervalMs` for
+      the inter-poll sleep; no literal `30` or `1000` remains at those two sites.
+- [ ] `MediaNetworkConfig` and the rest of the polling logic / HTTP client are
+      unchanged.
+- [ ] `sbt compile` and `sbt test` pass; `MusicPollConfigSpec` runs green.


### PR DESCRIPTION
# music-poll-config

## Problem

`MusicGeneration.pollPrediction`
(`src/main/scala/org/llm4s/szork/media/MusicGeneration.scala`) hardcodes its
polling behaviour:

- `maxAttempts: Int = 30` (method default parameter)
- `Thread.sleep(1000)` between polls (the "Wait 1 second before polling again" line)

Neither value is configurable, so a deployment cannot tune how long Szork waits
for a Replicate music prediction to finish.

This mirrors the gap that `MediaNetworkConfig`
(`src/main/scala/org/llm4s/szork/api/MediaNetworkConfig.scala`) already closed for
the media HTTP connect/read timeouts.

## Approach

Add a small `MusicPollConfig` case class + companion in the `org.llm4s.szork.api`
package, modelled exactly on `MediaNetworkConfig`:

- Fields with defaults equal to the current literals:
  - `maxAttempts: Int = 30`
  - `pollIntervalMs: Int = 1000`
- An env-overridable `load(reader: ConfigReader = EnvLoader)` reading
  `SZORK_MUSIC_POLL_MAX_ATTEMPTS` and `SZORK_MUSIC_POLL_INTERVAL_MS` (each parsed
  via `Try(_.toInt).toOption`, falling back to the defaults when absent or
  unparseable), plus a `lazy val instance = load()`.
- Route `MusicGeneration.pollPrediction` through `MusicPollConfig.instance`: the
  `maxAttempts` default parameter becomes `MusicPollConfig.instance.maxAttempts`
  and `Thread.sleep(1000)` becomes
  `Thread.sleep(MusicPollConfig.instance.pollIntervalMs)`. Default behaviour is
  unchanged (defaults equal the old literals).
- A unit test `MusicPollConfigSpec` mirroring `MediaNetworkConfigSpec`: defaults
  equal the historical literals, and the two env vars override (including
  unparseable-value fallback).

## Non-goals

- No change to the polling logic itself, the HTTP client, or any other media class.
- No change to `MediaNetworkConfig`.

## Decisions

Single piece **p1** — small, self-contained: add `MusicPollConfig`, route
`pollPrediction` through it, add `MusicPollConfigSpec`.
