### PR TITLE
[design] Adventure-gen retry config

### DIFF
--- a/.forge/specs/adventure-gen-retry-config/decomposition.md
+++ b/.forge/specs/adventure-gen-retry-config/decomposition.md
@@ -1,0 +1,22 @@
+# Adventure-gen retry config
+
+> Feature **adventure-gen-retry-config** — base branch `main`,
+> branch prefix `forge`.
+
+## Pieces
+
+<!-- forge:order-start -->
+1. <!-- forge:piece p1 -->**p1: Extract adventure-gen retry/back-off into AdventureGenConfig**<!-- /forge:piece -->
+   <!-- forge:editable-summary p1 -->
+   Add an env-overridable AdventureGenConfig mirroring MusicPollConfig and rewire AdventureGenerator to use it.
+   <!-- /forge:editable-summary -->
+   <!-- forge:status p1 -->`pending`<!-- /forge:status -->
+
+<!-- forge:order-end -->
+
+---
+
+*Rendered by [Forge](https://github.com/anthropics/forge) from
+`manifest.json`. Edit a piece summary or reorder the list between the
+`forge:order-start` / `forge:order-end` markers above, then run
+`forge reconcile adventure-gen-retry-config` to import the change.*

--- a/.forge/specs/adventure-gen-retry-config/design.md
+++ b/.forge/specs/adventure-gen-retry-config/design.md
@@ -1,0 +1,83 @@
+# Design — adventure-gen-retry-config
+
+## Problem
+
+`AdventureGenerator.generateAdventureOutline`
+(`src/main/scala/org/llm4s/szork/game/AdventureGenerator.scala`) hardcodes
+two retry/back-off values inline:
+
+- `val maxRetries = 2` (around line 196), controlling how many times
+  adventure-outline generation is retried.
+- `Thread.sleep(500)` (lines 218 and 226), the back-off pause between
+  retry attempts.
+
+These literals cannot be tuned per deployment. A flaky or slow LLM
+backend may warrant more retries or a longer back-off; a latency-sensitive
+deployment may want fewer/shorter. Today the only way to change either is
+to edit and recompile the source.
+
+## Approach
+
+Introduce a small configuration object `AdventureGenConfig`, modelled
+exactly on the existing `org.llm4s.szork.api.MusicPollConfig`
+(`src/main/scala/org/llm4s/szork/api/MusicPollConfig.scala`):
+
+- A `case class AdventureGenConfig(maxRetries: Int = 2, retryBackoffMs: Int = 500)`
+  whose field defaults equal the current inline literals, so default
+  runtime behaviour is unchanged.
+- A companion `object` with:
+  - `lazy val instance: AdventureGenConfig = load()`
+  - `def load(reader: ConfigReader = EnvLoader): AdventureGenConfig` that
+    reads each value from an environment override, falling back to the
+    default when the override is absent or unparseable (using the same
+    `reader.get(...).flatMap(v => Try(v.toInt).toOption).getOrElse(default)`
+    pattern as `MusicPollConfig`).
+
+Environment overrides:
+
+| Field            | Default | Env var                              |
+|------------------|---------|--------------------------------------|
+| `maxRetries`     | `2`     | `SZORK_ADVENTURE_GEN_MAX_RETRIES`    |
+| `retryBackoffMs` | `500`   | `SZORK_ADVENTURE_GEN_RETRY_BACKOFF_MS` |
+
+`AdventureGenerator.generateAdventureOutline` is then rewired to read
+`AdventureGenConfig.instance` once at the top of the retry loop and use
+`config.maxRetries` in place of the local `val maxRetries` and
+`config.retryBackoffMs` in place of the two `Thread.sleep(500)` literals.
+
+### Package placement
+
+`AdventureGenConfig` is a config peer of `MusicPollConfig`. To keep config
+objects together and follow the existing convention, place it in the same
+package as `MusicPollConfig`: `org.llm4s.szork.api`, file
+`src/main/scala/org/llm4s/szork/api/AdventureGenConfig.scala`.
+`AdventureGenerator` (in `org.llm4s.szork.game`) imports it. This keeps the
+change confined to the `game` and `api` packages as required by the brief.
+
+### Documentation (acceptance criterion)
+
+`AdventureGenConfig` is treated as public API and MUST carry ScalaDoc on:
+
+1. The `case class` — explaining its purpose and that defaults equal the
+   historical inline literals.
+2. The companion `load` factory method — using explicit `@param` and
+   `@return` tags, one per parameter, each a complete, naturally-reading
+   sentence on a single line. See `pieces/p1.md` for the exact required
+   shape.
+
+## Non-goals
+
+- No change to default runtime behaviour (defaults equal current literals).
+- No change to the retry/parse logic itself, the LLM prompt, or any other
+  behaviour of `AdventureGenerator`.
+- No new config keys beyond the two named above.
+- No changes outside the `game` and `api` packages.
+- No broader configuration framework or refactor of `MusicPollConfig`.
+
+## Decisions taken
+
+- **Package**: `org.llm4s.szork.api` (alongside `MusicPollConfig`), rather
+  than `org.llm4s.szork.game`, to keep config objects co-located and
+  consistent. The brief permits both packages.
+- **Single piece**: the change is small and self-contained; it ships as
+  one reviewable PR.

--- a/.forge/specs/adventure-gen-retry-config/manifest.json
+++ b/.forge/specs/adventure-gen-retry-config/manifest.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "featureId": "adventure-gen-retry-config",
+  "title": "Adventure-gen retry config",
+  "baseBranch": "main",
+  "branchPrefix": "forge",
+  "mode": "claude-driver",
+  "designPr": null,
+  "pieces": [
+    {
+      "id": "p1",
+      "order": 1,
+      "title": "Extract adventure-gen retry/back-off into AdventureGenConfig",
+      "summary": "Add an env-overridable AdventureGenConfig mirroring MusicPollConfig and rewire AdventureGenerator to use it.",
+      "specPath": "pieces/p1.md",
+      "acceptanceHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "status": "pending",
+      "baseSha": null,
+      "prNumber": null,
+      "mergeCommit": null,
+      "mergedAt": null,
+      "attempts": 0
+    }
+  ]
+}

--- a/.forge/specs/adventure-gen-retry-config/pieces/p1.md
+++ b/.forge/specs/adventure-gen-retry-config/pieces/p1.md
@@ -1,0 +1,83 @@
+# p1 — Extract adventure-gen retry/back-off into AdventureGenConfig
+
+## Summary
+
+Introduce an env-overridable `AdventureGenConfig` that mirrors
+`org.llm4s.szork.api.MusicPollConfig` in shape and style, and rewire
+`AdventureGenerator.generateAdventureOutline` to read its retry count and
+back-off pause from `AdventureGenConfig.instance` instead of inline
+literals. Default behaviour must be unchanged.
+
+## Scope
+
+- **New file**: `src/main/scala/org/llm4s/szork/api/AdventureGenConfig.scala`
+- **Edit**: `src/main/scala/org/llm4s/szork/game/AdventureGenerator.scala`
+
+Do not touch any code outside the `org.llm4s.szork.api` and
+`org.llm4s.szork.game` packages.
+
+## Implementation notes
+
+### `AdventureGenConfig`
+
+Model it directly on `MusicPollConfig`:
+
+- `package org.llm4s.szork.api`
+- imports `org.llm4s.config.{ConfigReader, EnvLoader}` and `scala.util.Try`
+- `case class AdventureGenConfig(maxRetries: Int = 2, retryBackoffMs: Int = 500)`
+- companion `object AdventureGenConfig` with:
+  - `lazy val instance: AdventureGenConfig = load()`
+  - `def load(reader: ConfigReader = EnvLoader): AdventureGenConfig` that
+    resolves each field via
+    `reader.get(ENV).flatMap(v => Try(v.toInt).toOption).getOrElse(default)`.
+
+Env var mapping:
+
+- `maxRetries` ← `SZORK_ADVENTURE_GEN_MAX_RETRIES` (default `2`)
+- `retryBackoffMs` ← `SZORK_ADVENTURE_GEN_RETRY_BACKOFF_MS` (default `500`)
+
+### Rewire `AdventureGenerator`
+
+- Import `org.llm4s.szork.api.AdventureGenConfig`.
+- At the top of the retry section (replacing `val maxRetries = 2`), read
+  `val config = AdventureGenConfig.instance`.
+- Use `config.maxRetries` everywhere the local `maxRetries` was used
+  (loop guard, `maxRetries + 1` log, `attempt > maxRetries` checks).
+- Replace both `Thread.sleep(500)` calls with
+  `Thread.sleep(config.retryBackoffMs.toLong)`.
+
+## Acceptance criteria
+
+1. New file `src/main/scala/org/llm4s/szork/api/AdventureGenConfig.scala`
+   exists, in package `org.llm4s.szork.api`, defining
+   `case class AdventureGenConfig(maxRetries: Int = 2, retryBackoffMs: Int = 500)`
+   with a companion `object` exposing `lazy val instance` and
+   `def load(reader: ConfigReader = EnvLoader): AdventureGenConfig`.
+2. Field defaults equal the historical literals exactly: `maxRetries = 2`,
+   `retryBackoffMs = 500`. With no env vars set, `AdventureGenConfig.instance`
+   equals `AdventureGenConfig(2, 500)`.
+3. `load` reads `SZORK_ADVENTURE_GEN_MAX_RETRIES` and
+   `SZORK_ADVENTURE_GEN_RETRY_BACKOFF_MS`, parsing each as an `Int` and
+   falling back to the default when the override is absent or unparseable
+   (verifiable by passing a stub `ConfigReader` to `load`).
+4. `AdventureGenerator.generateAdventureOutline` no longer contains the
+   literals `val maxRetries = 2` or `Thread.sleep(500)`; it reads both
+   values from `AdventureGenConfig.instance`.
+5. **Documentation (non-negotiable)**: both the `case class` and the
+   companion `load` method carry ScalaDoc. The `load` ScalaDoc uses
+   explicit `@param` and `@return` tags — one `@param` per parameter and
+   one `@return` — each description a complete, naturally-reading sentence
+   on the same line as its tag. Required shape:
+
+   ```
+   /** Loads the adventure-generation retry configuration from the environment, falling back to the historical inline defaults when an override is absent or unparseable.
+     *
+     * @param reader the configuration source to read environment overrides from; defaults to the process environment loader
+     * @return a fully-resolved AdventureGenConfig whose fields equal the environment overrides where present and the historical defaults otherwise
+     */
+   ```
+
+6. The change is confined to the `game` and `api` packages; no other files
+   are modified.
+7. `sbt compile` succeeds and existing tests continue to pass
+   (`sbt test`).


### PR DESCRIPTION
# Design — adventure-gen-retry-config

## Problem

`AdventureGenerator.generateAdventureOutline`
(`src/main/scala/org/llm4s/szork/game/AdventureGenerator.scala`) hardcodes
two retry/back-off values inline:

- `val maxRetries = 2` (around line 196), controlling how many times
  adventure-outline generation is retried.
- `Thread.sleep(500)` (lines 218 and 226), the back-off pause between
  retry attempts.

These literals cannot be tuned per deployment. A flaky or slow LLM
backend may warrant more retries or a longer back-off; a latency-sensitive
deployment may want fewer/shorter. Today the only way to change either is
to edit and recompile the source.

## Approach

Introduce a small configuration object `AdventureGenConfig`, modelled
exactly on the existing `org.llm4s.szork.api.MusicPollConfig`
(`src/main/scala/org/llm4s/szork/api/MusicPollConfig.scala`):

- A `case class AdventureGenConfig(maxRetries: Int = 2, retryBackoffMs: Int = 500)`
  whose field defaults equal the current inline literals, so default
  runtime behaviour is unchanged.
- A companion `object` with:
  - `lazy val instance: AdventureGenConfig = load()`
  - `def load(reader: ConfigReader = EnvLoader): AdventureGenConfig` that
    reads each value from an environment override, falling back to the
    default when the override is absent or unparseable (using the same
    `reader.get(...).flatMap(v => Try(v.toInt).toOption).getOrElse(default)`
    pattern as `MusicPollConfig`).

Environment overrides:

| Field            | Default | Env var                              |
|------------------|---------|--------------------------------------|
| `maxRetries`     | `2`     | `SZORK_ADVENTURE_GEN_MAX_RETRIES`    |
| `retryBackoffMs` | `500`   | `SZORK_ADVENTURE_GEN_RETRY_BACKOFF_MS` |

`AdventureGenerator.generateAdventureOutline` is then rewired to read
`AdventureGenConfig.instance` once at the top of the retry loop and use
`config.maxRetries` in place of the local `val maxRetries` and
`config.retryBackoffMs` in place of the two `Thread.sleep(500)` literals.

### Package placement

`AdventureGenConfig` is a config peer of `MusicPollConfig`. To keep config
objects together and follow the existing convention, place it in the same
package as `MusicPollConfig`: `org.llm4s.szork.api`, file
`src/main/scala/org/llm4s/szork/api/AdventureGenConfig.scala`.
`AdventureGenerator` (in `org.llm4s.szork.game`) imports it. This keeps the
change confined to the `game` and `api` packages as required by the brief.

### Documentation (acceptance criterion)

`AdventureGenConfig` is treated as public API and MUST carry ScalaDoc on:

1. The `case class` — explaining its purpose and that defaults equal the
   historical inline literals.
2. The companion `load` factory method — using explicit `@param` and
   `@return` tags, one per parameter, each a complete, naturally-reading
   sentence on a single line. See `pieces/p1.md` for the exact required
   shape.

## Non-goals

- No change to default runtime behaviour (defaults equal current literals).
- No change to the retry/parse logic itself, the LLM prompt, or any other
  behaviour of `AdventureGenerator`.
- No new config keys beyond the two named above.
- No changes outside the `game` and `api` packages.
- No broader configuration framework or refactor of `MusicPollConfig`.

## Decisions taken

- **Package**: `org.llm4s.szork.api` (alongside `MusicPollConfig`), rather
  than `org.llm4s.szork.game`, to keep config objects co-located and
  consistent. The brief permits both packages.
- **Single piece**: the change is small and self-contained; it ships as
  one reviewable PR.
