### PR TITLE
Extract adventure-gen retry/back-off into AdventureGenConfig

### DIFF
--- a/.forge/specs/adventure-gen-retry-config/decomposition.md
+++ b/.forge/specs/adventure-gen-retry-config/decomposition.md
@@ -2,6 +2,7 @@
 
 > Feature **adventure-gen-retry-config** — base branch `main`,
 > branch prefix `forge`.
+> Design PR: #18
 
 ## Pieces
 
@@ -10,7 +11,7 @@
    <!-- forge:editable-summary p1 -->
    Add an env-overridable AdventureGenConfig mirroring MusicPollConfig and rewire AdventureGenerator to use it.
    <!-- /forge:editable-summary -->
-   <!-- forge:status p1 -->`pending`<!-- /forge:status -->
+   <!-- forge:status p1 -->`in progress`<!-- /forge:status -->
 
 <!-- forge:order-end -->
 

--- a/.forge/specs/adventure-gen-retry-config/design.md
+++ b/.forge/specs/adventure-gen-retry-config/design.md
@@ -29,9 +29,23 @@ exactly on the existing `org.llm4s.szork.api.MusicPollConfig`
   - `lazy val instance: AdventureGenConfig = load()`
   - `def load(reader: ConfigReader = EnvLoader): AdventureGenConfig` that
     reads each value from an environment override, falling back to the
-    default when the override is absent or unparseable (using the same
-    `reader.get(...).flatMap(v => Try(v.toInt).toOption).getOrElse(default)`
-    pattern as `MusicPollConfig`).
+    default when the override is absent, unparseable, **or negative**. It
+    follows the `MusicPollConfig` pattern with an added non-negativity
+    guard:
+    `reader.get(...).flatMap(v => Try(v.toInt).toOption).filter(_ >= 0).getOrElse(default)`.
+
+### Input validation
+
+A syntactically valid but negative override would silently break
+generation rather than tune it: a negative `maxRetries` makes the
+`while (attempt <= maxRetries)` loop never enter (no generation attempt at
+all), and a negative `retryBackoffMs` throws `IllegalArgumentException`
+from `Thread.sleep(...)` after the first retryable failure. To keep an
+invalid env value from taking down a deployment, `load` treats a negative
+override the same as an absent/unparseable one and falls back to the
+historical default. Zero is permitted for both fields (`maxRetries = 0`
+means a single attempt with no retries; `retryBackoffMs = 0` means no
+back-off pause), so the guard is `_ >= 0`, not `_ > 0`.
 
 Environment overrides:
 
@@ -71,6 +85,8 @@ change confined to the `game` and `api` packages as required by the brief.
 - No change to the retry/parse logic itself, the LLM prompt, or any other
   behaviour of `AdventureGenerator`.
 - No new config keys beyond the two named above.
+- No clamping or coercion of negative overrides to a nearby valid value;
+  negative inputs simply fall back to the historical default.
 - No changes outside the `game` and `api` packages.
 - No broader configuration framework or refactor of `MusicPollConfig`.
 

--- a/.forge/specs/adventure-gen-retry-config/manifest.json
+++ b/.forge/specs/adventure-gen-retry-config/manifest.json
@@ -19,7 +19,7 @@
       "prNumber": 19,
       "mergeCommit": null,
       "mergedAt": null,
-      "attempts": 0
+      "attempts": 1
     }
   ]
 }

--- a/.forge/specs/adventure-gen-retry-config/manifest.json
+++ b/.forge/specs/adventure-gen-retry-config/manifest.json
@@ -16,7 +16,7 @@
       "acceptanceHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
       "status": "in_progress",
       "baseSha": "faa363509cfe30e69f27b25ab56c99899d4bdd6e",
-      "prNumber": null,
+      "prNumber": 19,
       "mergeCommit": null,
       "mergedAt": null,
       "attempts": 0

--- a/.forge/specs/adventure-gen-retry-config/manifest.json
+++ b/.forge/specs/adventure-gen-retry-config/manifest.json
@@ -5,7 +5,7 @@
   "baseBranch": "main",
   "branchPrefix": "forge",
   "mode": "claude-driver",
-  "designPr": null,
+  "designPr": 18,
   "pieces": [
     {
       "id": "p1",
@@ -14,8 +14,8 @@
       "summary": "Add an env-overridable AdventureGenConfig mirroring MusicPollConfig and rewire AdventureGenerator to use it.",
       "specPath": "pieces/p1.md",
       "acceptanceHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-      "status": "pending",
-      "baseSha": null,
+      "status": "in_progress",
+      "baseSha": "faa363509cfe30e69f27b25ab56c99899d4bdd6e",
       "prNumber": null,
       "mergeCommit": null,
       "mergedAt": null,

--- a/.forge/specs/adventure-gen-retry-config/pieces/p1.failures.md
+++ b/.forge/specs/adventure-gen-retry-config/pieces/p1.failures.md
@@ -1,0 +1,12 @@
+# Piece p1 — failures to address (PR #19)
+
+These CI checks on the piece's PR did not pass (`gh pr checks`):
+
+```
+backend	pass	1m45s	https://github.com/llm4s/szork/actions/runs/27001218887/job/79681894071	
+frontend	pass	28s	https://github.com/llm4s/szork/actions/runs/27001218887/job/79681894169
+```
+
+Make the smallest change that makes the failing check(s) pass. For a formatting
+check, run the project's formatter on the changed files (a targeted format is
+fine — do NOT run the full test suite). Then stop; Forge commits and re-runs CI.

--- a/.forge/specs/adventure-gen-retry-config/pieces/p1.md
+++ b/.forge/specs/adventure-gen-retry-config/pieces/p1.md
@@ -29,7 +29,15 @@ Model it directly on `MusicPollConfig`:
   - `lazy val instance: AdventureGenConfig = load()`
   - `def load(reader: ConfigReader = EnvLoader): AdventureGenConfig` that
     resolves each field via
-    `reader.get(ENV).flatMap(v => Try(v.toInt).toOption).getOrElse(default)`.
+    `reader.get(ENV).flatMap(v => Try(v.toInt).toOption).filter(_ >= 0).getOrElse(default)`.
+
+The `.filter(_ >= 0)` guard is required (not just stylistic): a negative
+override is syntactically valid but breaks generation — a negative
+`maxRetries` makes `while (attempt <= maxRetries)` never enter (zero
+generation attempts) and a negative `retryBackoffMs` throws
+`IllegalArgumentException` from `Thread.sleep(...)`. Treat a negative
+value the same as absent/unparseable and fall back to the default. Zero is
+valid for both fields, so use `_ >= 0` (not `_ > 0`).
 
 Env var mapping:
 
@@ -58,8 +66,11 @@ Env var mapping:
    equals `AdventureGenConfig(2, 500)`.
 3. `load` reads `SZORK_ADVENTURE_GEN_MAX_RETRIES` and
    `SZORK_ADVENTURE_GEN_RETRY_BACKOFF_MS`, parsing each as an `Int` and
-   falling back to the default when the override is absent or unparseable
-   (verifiable by passing a stub `ConfigReader` to `load`).
+   falling back to the default when the override is absent, unparseable,
+   **or negative** (verifiable by passing a stub `ConfigReader` to
+   `load`). A non-negative override (including `0`) is accepted as-is;
+   a negative override falls back to the historical default so an invalid
+   env value cannot skip generation entirely or throw from `Thread.sleep`.
 4. `AdventureGenerator.generateAdventureOutline` no longer contains the
    literals `val maxRetries = 2` or `Thread.sleep(500)`; it reads both
    values from `AdventureGenConfig.instance`.

--- a/src/main/scala/org/llm4s/szork/api/AdventureGenConfig.scala
+++ b/src/main/scala/org/llm4s/szork/api/AdventureGenConfig.scala
@@ -16,10 +16,14 @@ case class AdventureGenConfig(
 object AdventureGenConfig {
   lazy val instance: AdventureGenConfig = load()
 
-  /** Loads the adventure-generation retry configuration from the environment, falling back to the historical inline defaults when an override is absent or unparseable.
+  /** Loads the adventure-generation retry configuration from the environment, falling back to the historical inline
+    * defaults when an override is absent or unparseable.
     *
-    * @param reader the configuration source to read environment overrides from; defaults to the process environment loader
-    * @return a fully-resolved AdventureGenConfig whose fields equal the environment overrides where present and the historical defaults otherwise
+    * @param reader
+    *   the configuration source to read environment overrides from; defaults to the process environment loader
+    * @return
+    *   a fully-resolved AdventureGenConfig whose fields equal the environment overrides where present and the
+    *   historical defaults otherwise
     */
   def load(reader: ConfigReader = EnvLoader): AdventureGenConfig = {
     val defaults = AdventureGenConfig()

--- a/src/main/scala/org/llm4s/szork/api/AdventureGenConfig.scala
+++ b/src/main/scala/org/llm4s/szork/api/AdventureGenConfig.scala
@@ -1,0 +1,44 @@
+package org.llm4s.szork.api
+
+import org.llm4s.config.{ConfigReader, EnvLoader}
+import scala.util.Try
+
+/** Retry/back-off behaviour for adventure-outline generation.
+  *
+  * Defaults equal the historical inline literals, so default behaviour is unchanged. Both values are env-overridable
+  * for per-deployment tuning.
+  */
+case class AdventureGenConfig(
+  maxRetries: Int = 2,
+  retryBackoffMs: Int = 500
+)
+
+object AdventureGenConfig {
+  lazy val instance: AdventureGenConfig = load()
+
+  /** Loads the adventure-generation retry configuration from the environment, falling back to the historical inline defaults when an override is absent or unparseable.
+    *
+    * @param reader the configuration source to read environment overrides from; defaults to the process environment loader
+    * @return a fully-resolved AdventureGenConfig whose fields equal the environment overrides where present and the historical defaults otherwise
+    */
+  def load(reader: ConfigReader = EnvLoader): AdventureGenConfig = {
+    val defaults = AdventureGenConfig()
+
+    val maxRetries = reader
+      .get("SZORK_ADVENTURE_GEN_MAX_RETRIES")
+      .flatMap(v => Try(v.toInt).toOption)
+      .filter(_ >= 0)
+      .getOrElse(defaults.maxRetries)
+
+    val retryBackoffMs = reader
+      .get("SZORK_ADVENTURE_GEN_RETRY_BACKOFF_MS")
+      .flatMap(v => Try(v.toInt).toOption)
+      .filter(_ >= 0)
+      .getOrElse(defaults.retryBackoffMs)
+
+    AdventureGenConfig(
+      maxRetries = maxRetries,
+      retryBackoffMs = retryBackoffMs
+    )
+  }
+}

--- a/src/main/scala/org/llm4s/szork/game/AdventureGenerator.scala
+++ b/src/main/scala/org/llm4s/szork/game/AdventureGenerator.scala
@@ -1,5 +1,6 @@
 package org.llm4s.szork.game
 
+import org.llm4s.szork.api.AdventureGenConfig
 import org.llm4s.szork.error._
 import org.llm4s.szork.error.ErrorHandling._
 import org.llm4s.llmconnect.LLMClient
@@ -193,13 +194,13 @@ object AdventureGenerator {
     )
 
     // Retry logic for better reliability
-    val maxRetries = 2
+    val config = AdventureGenConfig.instance
     var attempt = 0
     var lastError: Option[SzorkError] = None
 
-    while (attempt <= maxRetries) {
+    while (attempt <= config.maxRetries) {
       attempt += 1
-      logger.info(s"Adventure generation attempt $attempt of ${maxRetries + 1}")
+      logger.info(s"Adventure generation attempt $attempt of ${config.maxRetries + 1}")
 
       client.complete(Conversation(messages)) match {
         case Right(completion) =>
@@ -211,19 +212,19 @@ object AdventureGenerator {
             case Left(error) =>
               logger.warn(s"Attempt $attempt failed to parse outline: ${error.message}")
               lastError = Some(error)
-              if (attempt > maxRetries) {
+              if (attempt > config.maxRetries) {
                 return Left(error)
               }
               // Wait a bit before retrying
-              Thread.sleep(500)
+              Thread.sleep(config.retryBackoffMs.toLong)
           }
         case Left(error) =>
           logger.error(s"Attempt $attempt failed to call LLM: $error")
           lastError = Some(LLMError(s"Failed to generate adventure outline: $error", retryable = true))
-          if (attempt > maxRetries) {
+          if (attempt > config.maxRetries) {
             return Left(lastError.get)
           }
-          Thread.sleep(500)
+          Thread.sleep(config.retryBackoffMs.toLong)
       }
     }
 


### PR DESCRIPTION
# Extract adventure-gen retry/back-off into AdventureGenConfig

> Piece **p1** of feature [Adventure-gen retry config](../specs/adventure-gen-retry-config/design.md).
> Design PR: #18

## Summary

Add an env-overridable AdventureGenConfig mirroring MusicPollConfig and rewire AdventureGenerator to use it.

## Spec

# p1 — Extract adventure-gen retry/back-off into AdventureGenConfig

## Summary

Introduce an env-overridable `AdventureGenConfig` that mirrors
`org.llm4s.szork.api.MusicPollConfig` in shape and style, and rewire
`AdventureGenerator.generateAdventureOutline` to read its retry count and
back-off pause from `AdventureGenConfig.instance` instead of inline
literals. Default behaviour must be unchanged.

## Scope

- **New file**: `src/main/scala/org/llm4s/szork/api/AdventureGenConfig.scala`
- **Edit**: `src/main/scala/org/llm4s/szork/game/AdventureGenerator.scala`

Do not touch any code outside the `org.llm4s.szork.api` and
`org.llm4s.szork.game` packages.

## Implementation notes

### `AdventureGenConfig`

Model it directly on `MusicPollConfig`:

- `package org.llm4s.szork.api`
- imports `org.llm4s.config.{ConfigReader, EnvLoader}` and `scala.util.Try`
- `case class AdventureGenConfig(maxRetries: Int = 2, retryBackoffMs: Int = 500)`
- companion `object AdventureGenConfig` with:
  - `lazy val instance: AdventureGenConfig = load()`
  - `def load(reader: ConfigReader = EnvLoader): AdventureGenConfig` that
    resolves each field via
    `reader.get(ENV).flatMap(v => Try(v.toInt).toOption).filter(_ >= 0).getOrElse(default)`.

The `.filter(_ >= 0)` guard is required (not just stylistic): a negative
override is syntactically valid but breaks generation — a negative
`maxRetries` makes `while (attempt <= maxRetries)` never enter (zero
generation attempts) and a negative `retryBackoffMs` throws
`IllegalArgumentException` from `Thread.sleep(...)`. Treat a negative
value the same as absent/unparseable and fall back to the default. Zero is
valid for both fields, so use `_ >= 0` (not `_ > 0`).

Env var mapping:

- `maxRetries` ← `SZORK_ADVENTURE_GEN_MAX_RETRIES` (default `2`)
- `retryBackoffMs` ← `SZORK_ADVENTURE_GEN_RETRY_BACKOFF_MS` (default `500`)

### Rewire `AdventureGenerator`

- Import `org.llm4s.szork.api.AdventureGenConfig`.
- At the top of the retry section (replacing `val maxRetries = 2`), read
  `val config = AdventureGenConfig.instance`.
- Use `config.maxRetries` everywhere the local `maxRetries` was used
  (loop guard, `maxRetries + 1` log, `attempt > maxRetries` checks).
- Replace both `Thread.sleep(500)` calls with
  `Thread.sleep(config.retryBackoffMs.toLong)`.

## Acceptance criteria

1. New file `src/main/scala/org/llm4s/szork/api/AdventureGenConfig.scala`
   exists, in package `org.llm4s.szork.api`, defining
   `case class AdventureGenConfig(maxRetries: Int = 2, retryBackoffMs: Int = 500)`
   with a companion `object` exposing `lazy val instance` and
   `def load(reader: ConfigReader = EnvLoader): AdventureGenConfig`.
2. Field defaults equal the historical literals exactly: `maxRetries = 2`,
   `retryBackoffMs = 500`. With no env vars set, `AdventureGenConfig.instance`
   equals `AdventureGenConfig(2, 500)`.
3. `load` reads `SZORK_ADVENTURE_GEN_MAX_RETRIES` and
   `SZORK_ADVENTURE_GEN_RETRY_BACKOFF_MS`, parsing each as an `Int` and
   falling back to the default when the override is absent, unparseable,
   **or negative** (verifiable by passing a stub `ConfigReader` to
   `load`). A non-negative override (including `0`) is accepted as-is;
   a negative override falls back to the historical default so an invalid
   env value cannot skip generation entirely or throw from `Thread.sleep`.
4. `AdventureGenerator.generateAdventureOutline` no longer contains the
   literals `val maxRetries = 2` or `Thread.sleep(500)`; it reads both
   values from `AdventureGenConfig.instance`.
5. **Documentation (non-negotiable)**: both the `case class` and the
   companion `load` method carry ScalaDoc. The `load` ScalaDoc uses
   explicit `@param` and `@return` tags — one `@param` per parameter and
   one `@return` — each description a complete, naturally-reading sentence
   on the same line as its tag. Required shape:

   ```
   /** Loads the adventure-generation retry configuration from the environment, falling back to the historical inline defaults when an override is absent or unparseable.
     *
     * @param reader the configuration source to read environment overrides from; defaults to the process environment loader
     * @return a fully-resolved AdventureGenConfig whose fields equal the environment overrides where present and the historical defaults otherwise
     */
   ```

6. The change is confined to the `game` and `api` packages; no other files
   are modified.
7. `sbt compile` succeeds and existing tests continue to pass
   (`sbt test`).


## Audit

Implemented by the Forge claude driver.

---

*Opened by [Forge](https://github.com/anthropics/forge). Reviewed by the cross-model reviewer; merged by a human after CI passes.*
